### PR TITLE
Add Gaia LLC multi-theme web design concepts

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,431 @@
+:root {
+  color-scheme: light dark;
+  --font-base: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  --spacing-xs: 0.5rem;
+  --spacing-sm: 0.75rem;
+  --spacing-md: 1.5rem;
+  --spacing-lg: 2.5rem;
+  --radius-sm: 0.75rem;
+  --radius-lg: 1.5rem;
+  --transition-base: 0.3s ease;
+  --shadow-soft: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  display: block;
+}
+
+h1, h2, h3, h4 {
+  margin-top: 0;
+  letter-spacing: -0.02em;
+}
+
+p {
+  margin-top: 0;
+}
+
+button {
+  font: inherit;
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1d4ed8;
+  color: #fff;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-sm);
+  z-index: 1000;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: var(--spacing-sm);
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  padding: var(--spacing-lg) 0;
+}
+
+.hero {
+  display: grid;
+  gap: var(--spacing-lg);
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin-bottom: var(--spacing-sm);
+}
+
+.hero-content p {
+  font-size: clamp(1.125rem, 2.5vw, 1.35rem);
+  max-width: 32rem;
+}
+
+.hero-media {
+  position: relative;
+}
+
+.hero-media::after {
+  content: '';
+  position: absolute;
+  inset: 8% -8% -10% 15%;
+  border-radius: var(--radius-lg);
+  z-index: -1;
+  opacity: 0.2;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+.section {
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.section-header h2 {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.grid {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  padding: var(--spacing-md);
+  border-radius: var(--radius-lg);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-soft);
+}
+
+.card h3 {
+  font-size: 1.25rem;
+  margin-bottom: var(--spacing-xs);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.list li {
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: flex-start;
+}
+
+.list li span {
+  font-weight: 600;
+}
+
+.cta-group {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-md);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  font-weight: 600;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
+  text-decoration: none;
+}
+
+.button.primary:focus-visible,
+.button.secondary:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.fact {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.fact span {
+  font-size: 0.9rem;
+  color: inherit;
+  opacity: 0.8;
+}
+
+.message {
+  display: grid;
+  gap: var(--spacing-sm);
+  font-size: 1.05rem;
+}
+
+footer {
+  margin-top: var(--spacing-lg);
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+/* Theme: Modern Minimal */
+body.theme-minimal {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+body.theme-minimal .badge {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  padding: 0.4rem 0.9rem;
+}
+
+body.theme-minimal .hero-media::after {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(14, 165, 233, 0.15));
+}
+
+body.theme-minimal .section {
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+body.theme-minimal .card {
+  background: #f1f5f9;
+}
+
+body.theme-minimal .button.primary {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+body.theme-minimal .button.primary:hover {
+  background: #1e3a8a;
+}
+
+body.theme-minimal .button.secondary {
+  background: rgba(15, 23, 42, 0.05);
+  color: #0f172a;
+}
+
+body.theme-minimal .button.secondary:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+/* Theme: Dark Gradient */
+body.theme-dark {
+  background: radial-gradient(circle at top, #0f172a, #020617);
+  color: #f8fafc;
+}
+
+body.theme-dark .container {
+  width: min(1180px, 94vw);
+}
+
+body.theme-dark .badge {
+  background: rgba(99, 102, 241, 0.25);
+  color: #a5b4fc;
+  padding: 0.4rem 1rem;
+}
+
+body.theme-dark .hero-media::after {
+  background: linear-gradient(160deg, rgba(79, 70, 229, 0.4), rgba(56, 189, 248, 0.25));
+}
+
+body.theme-dark .section {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  backdrop-filter: blur(16px);
+}
+
+body.theme-dark .card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+body.theme-dark .button.primary {
+  background: linear-gradient(135deg, #6366f1, #38bdf8);
+  color: #fff;
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.35);
+}
+
+body.theme-dark .button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 25px 50px rgba(56, 189, 248, 0.45);
+}
+
+body.theme-dark .button.secondary {
+  background: rgba(148, 163, 184, 0.12);
+  color: #f8fafc;
+}
+
+body.theme-dark .button.secondary:hover {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+/* Theme: Bold Visual */
+body.theme-bold {
+  background: #fff;
+  color: #111827;
+}
+
+body.theme-bold .container {
+  width: min(1200px, 94vw);
+}
+
+body.theme-bold .badge {
+  background: #f97316;
+  color: #fff7ed;
+  padding: 0.45rem 1rem;
+}
+
+body.theme-bold .hero {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+body.theme-bold .hero-media::after {
+  background: linear-gradient(150deg, rgba(239, 68, 68, 0.3), rgba(249, 115, 22, 0.25));
+}
+
+body.theme-bold .hero-content h1 {
+  font-size: clamp(2.75rem, 5vw, 4rem);
+  text-transform: uppercase;
+  letter-spacing: -0.04em;
+}
+
+body.theme-bold .hero-content p {
+  font-size: clamp(1.125rem, 2.6vw, 1.45rem);
+}
+
+body.theme-bold .section {
+  background: #0f172a;
+  color: #e2e8f0;
+  position: relative;
+  overflow: hidden;
+}
+
+body.theme-bold .section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(248, 113, 113, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 30%, rgba(251, 191, 36, 0.25), transparent 60%);
+  z-index: 0;
+}
+
+body.theme-bold .section > * {
+  position: relative;
+  z-index: 1;
+}
+
+body.theme-bold .card {
+  background: #fff;
+  color: #0f172a;
+  border: none;
+  box-shadow: var(--shadow-soft);
+}
+
+body.theme-bold .button.primary {
+  background: #ef4444;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+body.theme-bold .button.primary:hover {
+  background: #b91c1c;
+}
+
+body.theme-bold .button.secondary {
+  background: #f97316;
+  color: #fff;
+}
+
+body.theme-bold footer {
+  color: #475569;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .section {
+    padding: var(--spacing-md);
+  }
+
+  .cta-group {
+    width: 100%;
+  }
+
+  .button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gaia LLC | デザインバリエーション</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body class="theme-minimal">
+    <a class="skip-link" href="#pattern-gallery">メインコンテンツへ移動</a>
+    <header>
+      <div class="container">
+        <div class="hero">
+          <div class="hero-content">
+            <span class="badge" aria-label="コンセプトコレクション">Design Library</span>
+            <h1>Gaia LLC Webデザイン提案</h1>
+            <p>
+              Atlassian Design System の原則に沿いながら、Gaia LLC の多角的な事業価値を伝えるための 3 つのデザインパターンをご用意しました。モダンな UI
+              体験を比較し、ブランドの方向性に最適なスタイルをご検討ください。
+            </p>
+          </div>
+          <div class="hero-media">
+            <img src="assets/images/gaia-overview.jpg" alt="多角的なビジネス領域を象徴する都市の俯瞰図" />
+          </div>
+        </div>
+      </div>
+    </header>
+    <main id="pattern-gallery" class="container" aria-label="デザインパターンギャラリー">
+      <div class="section" style="background: transparent; box-shadow: none; padding: 0;">
+        <div class="section-header">
+          <h2>デザインパターンを切り替える</h2>
+          <p>タブまたはキーボード（← →）でレイアウトを切り替えてプレビューできます。</p>
+        </div>
+        <nav role="tablist" aria-label="Gaia LLC デザインパターン">
+          <div class="cta-group" role="presentation">
+            <button type="button" role="tab" id="tab-pattern-1" aria-controls="panel-pattern-1" aria-selected="true" class="button primary">モダンミニマル</button>
+            <button type="button" role="tab" id="tab-pattern-2" aria-controls="panel-pattern-2" aria-selected="false" class="button secondary">ダーク × グラデーション</button>
+            <button type="button" role="tab" id="tab-pattern-3" aria-controls="panel-pattern-3" aria-selected="false" class="button secondary">ビジュアルリッチ</button>
+          </div>
+        </nav>
+      </div>
+      <section role="tabpanel" id="panel-pattern-1" aria-labelledby="tab-pattern-1">
+        <iframe
+          src="pattern-1.html"
+          title="Gaia LLC モダンミニマルデザイン"
+          style="width: 100%; border: none; min-height: 1200px; border-radius: var(--radius-lg); box-shadow: var(--shadow-soft);"
+          loading="lazy"
+        ></iframe>
+      </section>
+      <section role="tabpanel" id="panel-pattern-2" aria-labelledby="tab-pattern-2" hidden aria-hidden="true">
+        <iframe
+          src="pattern-2.html"
+          title="Gaia LLC ダークモードグラデーションデザイン"
+          style="width: 100%; border: none; min-height: 1200px; border-radius: var(--radius-lg); box-shadow: var(--shadow-soft);"
+          loading="lazy"
+        ></iframe>
+      </section>
+      <section role="tabpanel" id="panel-pattern-3" aria-labelledby="tab-pattern-3" hidden aria-hidden="true">
+        <iframe
+          src="pattern-3.html"
+          title="Gaia LLC ビジュアルリッチデザイン"
+          style="width: 100%; border: none; min-height: 1200px; border-radius: var(--radius-lg); box-shadow: var(--shadow-soft);"
+          loading="lazy"
+        ></iframe>
+      </section>
+    </main>
+    <footer class="container">
+      <p>© <time datetime="2024">2024</time> Gaia LLC — デザインコンセプト比較プレビュー</p>
+    </footer>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/pattern-1.html
+++ b/pattern-1.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gaia LLC | モダンミニマル</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body class="theme-minimal">
+    <a class="skip-link" href="#main">メインコンテンツへ移動</a>
+    <header>
+      <div class="container hero">
+        <div class="hero-content">
+          <span class="badge">Value Creation</span>
+          <h1>静けさの中で研ぎ澄まされた価値創造</h1>
+          <p>
+            Gaia LLC は不動産開発から看板事業、保険代理店まで幅広いソリューションを、クリーンで信頼感のあるユーザー体験とともに提供します。ミニマルな UI でメッセージを際立たせ、訪問者の理解を助けます。
+          </p>
+          <div class="cta-group">
+            <a class="button primary" href="#value-creation">価値創造を見る</a>
+            <a class="button secondary" href="#company">会社概要へ</a>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="assets/images/value-creation-minimal.jpg" alt="整然とした建築空間と自然光が差し込むモダンなロビー" />
+        </div>
+      </div>
+    </header>
+    <main id="main" class="container">
+      <section id="value-creation" class="section" aria-labelledby="value-title">
+        <div class="section-header">
+          <h2 id="value-title">VALUE CREATION｜価値創造</h2>
+          <p>顧客・地域・未来につながる価値の連鎖をデザインします。</p>
+        </div>
+        <div class="grid two">
+          <article class="card">
+            <h3>多層的な不動産ソリューション</h3>
+            <p>賃貸から別荘地開発まで、データと現場感覚を融合させた最適提案を行います。</p>
+            <img src="assets/images/realestate-insight.jpg" alt="都市の俯瞰図とデータが重なる不動産分析イメージ" />
+          </article>
+          <article class="card">
+            <h3>感性を生かしたデザイン</h3>
+            <p>陶芸や広告看板のプロジェクトで磨いた造形感覚を、ブランド体験全体へ応用します。</p>
+            <img src="assets/images/design-craft.jpg" alt="陶芸作品とデザイナーのスケッチが並ぶ作業机" />
+          </article>
+        </div>
+      </section>
+
+      <section id="services" class="section" aria-labelledby="service-title">
+        <div class="section-header">
+          <h2 id="service-title">事業の目的</h2>
+          <p>専門領域とネットワークを掛け合わせ、総合的な価値を提供します。</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <ul class="list" aria-label="Gaia LLC の事業領域一覧">
+              <li><span aria-hidden="true">•</span>不動産事業・不動産コンサルタント業務</li>
+              <li><span aria-hidden="true">•</span>建築の工事設計と住宅地・別荘地の開発造成</li>
+              <li><span aria-hidden="true">•</span>広告看板事業とストリートサイド広告の企画</li>
+              <li><span aria-hidden="true">•</span>生命保険募集・損害保険代理店事業</li>
+            </ul>
+          </div>
+          <div>
+            <img src="assets/images/service-collage.jpg" alt="建築図面と看板デザイン、保険相談の様子を重ねたコラージュ" />
+          </div>
+        </div>
+      </section>
+
+      <section id="company" class="section" aria-labelledby="company-title">
+        <div class="section-header">
+          <h2 id="company-title">会社概要</h2>
+          <p>熊本に根ざし、全国視点で価値を届ける合同会社ガイア。</p>
+        </div>
+        <div class="grid two">
+          <div class="card">
+            <h3>法人情報</h3>
+            <div class="fact"><span>社名</span>Gaiya LLC（合同会社ガイア）</div>
+            <div class="fact"><span>資本金</span>200万円</div>
+            <div class="fact"><span>所在地</span>熊本県熊本市中央区帯山５丁目３８番２５号</div>
+            <div class="fact"><span>設立</span>平成25年11月1日</div>
+            <div class="fact"><span>法人番号</span>5330003005421</div>
+          </div>
+          <div class="card">
+            <h3>地域との共創</h3>
+            <p>地域社会やパートナーとの協業を重視し、持続可能なまちづくりに貢献しています。</p>
+            <img src="assets/images/kumamoto-community.jpg" alt="熊本市の街並みと地域コミュニティの風景" />
+          </div>
+        </div>
+      </section>
+
+      <section id="presentation" class="section" aria-labelledby="presentation-title">
+        <div class="section-header">
+          <h2 id="presentation-title">プレゼンテーションのハイライト</h2>
+          <p>クラフトの感性と戦略性を兼ね備えたアプローチ。</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>陶芸 Design × Place</h3>
+            <p>独自の造形美から空間ブランディングを発想し、質感を伴う体験を設計。</p>
+            <img src="assets/images/ceramics-gallery.jpg" alt="陶芸作品が並ぶギャラリー空間" />
+          </article>
+          <article class="card">
+            <h3>Creation</h3>
+            <p>自由な創造力で既存の枠にとらわれないコンセプトを構築します。</p>
+            <img src="assets/images/creative-workshop.jpg" alt="クリエイターがアイデアを出し合うワークショップ" />
+          </article>
+          <article class="card">
+            <h3>Signboard Business</h3>
+            <p>媒体価値とロケーションを最適化し、唯一無二の広告体験を提案。</p>
+            <img src="assets/images/signage-design.jpg" alt="夜の街に映える洗練された看板広告" />
+          </article>
+        </div>
+      </section>
+
+      <section id="message" class="section" aria-labelledby="message-title">
+        <div class="section-header">
+          <h2 id="message-title">Message</h2>
+        </div>
+        <div class="message">
+          <p>
+            私たちの使命は「価値を創造し、社会に還元すること」です。激しく変化する現代社会で求められる本質を問い続け、ユーザー視点と未来志向を軸に挑戦を続けています。
+          </p>
+          <p>
+            お客様・パートナー・地域社会とのつながりを大切にし、共創の輪を広げることで新たな価値を創造します。持続可能な社会の実現に向け、変化を恐れず前進します。
+          </p>
+          <p>代表社員 井上真意</p>
+        </div>
+      </section>
+
+      <section id="mission" class="section" aria-labelledby="mission-title">
+        <div class="section-header">
+          <h2 id="mission-title">Mission</h2>
+          <p>最適な価値を提案し、カタチにするプロフェッショナルチーム。</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <p>独自ネットワークを活かした不動産の専門知識と、創造力豊かなデザイン思考で、お客様の期待を超えるソリューションを提供します。</p>
+            <a class="button primary" href="#value-creation">価値創造を再確認</a>
+          </div>
+          <div>
+            <img src="assets/images/mission-realestate.jpg" alt="専門家が不動産プロジェクトを議論している様子" />
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="container">
+      <p>© Gaia LLC — Minimal &amp; Focused Design</p>
+    </footer>
+  </body>
+</html>

--- a/pattern-2.html
+++ b/pattern-2.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gaia LLC | ダークモード × グラデーション</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body class="theme-dark">
+    <a class="skip-link" href="#main">メインコンテンツへ移動</a>
+    <header>
+      <div class="container hero">
+        <div class="hero-content">
+          <span class="badge">Future Forward</span>
+          <h1>夜明け前の都市に灯る価値の光</h1>
+          <p>
+            ダークモードに浮かぶ透明感のある UI。Gaia LLC の多角的なビジネスを、ガラスモーフィズムとグラデーションで未来的に表現し、投資家と顧客の期待感を高めます。
+          </p>
+          <div class="cta-group">
+            <a class="button primary" href="#value-creation">ソリューションを見る</a>
+            <a class="button secondary" href="#message">ビジョンを読む</a>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="assets/images/futuristic-city-gradient.jpg" alt="夜明けの都市景観に広がるグラデーションの光" />
+        </div>
+      </div>
+    </header>
+    <main id="main" class="container">
+      <section id="value-creation" class="section" aria-labelledby="value-title">
+        <div class="section-header">
+          <h2 id="value-title">VALUE CREATION｜価値創造</h2>
+          <p>光と陰を操りながら、価値のエコシステムを構築します。</p>
+        </div>
+        <div class="grid two">
+          <article class="card">
+            <h3>ハイブリッド不動産戦略</h3>
+            <p>データインテリジェンスと現地の洞察を結び、賃貸から投資案件までスマートに最適化。</p>
+            <img src="assets/images/digital-realestate.jpg" alt="夜景の上に浮かぶデジタルな不動産データ可視化" />
+          </article>
+          <article class="card">
+            <h3>メディアミックス・デザイン</h3>
+            <p>看板広告とデジタル施策を掛け合わせ、街に光るブランド体験を創出します。</p>
+            <img src="assets/images/gradient-signboard.jpg" alt="ネオンの光が映えるグラデーション看板" />
+          </article>
+        </div>
+      </section>
+
+      <section id="services" class="section" aria-labelledby="service-title">
+        <div class="section-header">
+          <h2 id="service-title">事業の目的</h2>
+          <p>専門領域を統合したインテリジェントなパートナーシップ。</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <ul class="list" aria-label="Gaia LLC の事業領域">
+              <li><span aria-hidden="true">•</span>不動産事業 / 不動産コンサルタント</li>
+              <li><span aria-hidden="true">•</span>建築工事設計 / 開発造成</li>
+              <li><span aria-hidden="true">•</span>広告看板・ストリートサイド広告</li>
+              <li><span aria-hidden="true">•</span>生命保険募集 / 損害保険代理店</li>
+            </ul>
+          </div>
+          <div>
+            <img src="assets/images/strategy-overlay.jpg" alt="複数のビジネスアイコンが重なるグラデーション背景" />
+          </div>
+        </div>
+      </section>
+
+      <section id="company" class="section" aria-labelledby="company-title">
+        <div class="section-header">
+          <h2 id="company-title">会社概要</h2>
+          <p>熊本発、未来志向のローカルプレミアムブランド。</p>
+        </div>
+        <div class="grid two">
+          <div class="card">
+            <h3>企業スペック</h3>
+            <div class="fact"><span>社名</span>Gaiya LLC（合同会社ガイア）</div>
+            <div class="fact"><span>資本金</span>200万円</div>
+            <div class="fact"><span>所在地</span>熊本県熊本市中央区帯山５丁目３８番２５号</div>
+            <div class="fact"><span>設立</span>平成25年11月1日</div>
+            <div class="fact"><span>法人番号</span>5330003005421</div>
+          </div>
+          <div class="card">
+            <h3>ローカル × グローバル</h3>
+            <p>地域との強固な信頼関係を基盤に、全国レベルのプロジェクトにも迅速に対応します。</p>
+            <img src="assets/images/night-kumamoto.jpg" alt="夜景に浮かぶ熊本城と都市の光" />
+          </div>
+        </div>
+      </section>
+
+      <section id="presentation" class="section" aria-labelledby="presentation-title">
+        <div class="section-header">
+          <h2 id="presentation-title">プレゼンテーション</h2>
+          <p>クラフトとテクノロジーの融合が、新しい価値の余白を生み出す。</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>陶芸 Design × Place</h3>
+            <p>素材の温度感と空間の光を計算したアートディレクション。</p>
+            <img src="assets/images/moody-ceramics.jpg" alt="スポットライトに照らされた陶芸作品" />
+          </article>
+          <article class="card">
+            <h3>Creation</h3>
+            <p>ダークトーンのキャンバスに鮮やかな発想を描くクリエイティブセッション。</p>
+            <img src="assets/images/creative-lab.jpg" alt="未来的なスタジオでブレインストーミングするチーム" />
+          </article>
+          <article class="card">
+            <h3>Signboard Business</h3>
+            <p>街路に溶け込む光の演出で、唯一無二の広告ストーリーを提案します。</p>
+            <img src="assets/images/glassmorphism-signage.jpg" alt="ガラスモーフィズム調のサインが光る夜の街角" />
+          </article>
+        </div>
+      </section>
+
+      <section id="message" class="section" aria-labelledby="message-title">
+        <div class="section-header">
+          <h2 id="message-title">Message</h2>
+          <p>価値創造の意思を透明な言葉で伝えます。</p>
+        </div>
+        <div class="message">
+          <p>
+            私たちの使命は「価値を創造し、社会に還元すること」。急速に変化する社会を照らす存在として、本質に向き合い続けます。
+          </p>
+          <p>
+            ユーザー視点と未来志向を両立させ、共創によって価値を高める。地域と共に成長し、サステナブルな明日を描きます。
+          </p>
+          <p>代表社員 井上真意</p>
+        </div>
+      </section>
+
+      <section id="mission" class="section" aria-labelledby="mission-title">
+        <div class="section-header">
+          <h2 id="mission-title">Mission</h2>
+          <p>最適な価値を提案し、実装するナビゲーター。</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <p>独自のネットワークと専門性を武器に、不動産からクリエイティブまでシームレスにサポートします。</p>
+            <a class="button primary" href="#services">事業全体を見る</a>
+          </div>
+          <div>
+            <img src="assets/images/dark-mission-team.jpg" alt="グラデーションライトの下で戦略を確認するチーム" />
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="container">
+      <p>© Gaia LLC — Nocturnal Gradient Experience</p>
+    </footer>
+  </body>
+</html>

--- a/pattern-3.html
+++ b/pattern-3.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gaia LLC | ビジュアルリッチ &amp; Bold</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body class="theme-bold">
+    <a class="skip-link" href="#main">メインコンテンツへ移動</a>
+    <header>
+      <div class="container hero">
+        <div class="hero-content">
+          <span class="badge">Gaia Vision</span>
+          <h1>Bold Impact for Gaia LLC</h1>
+          <p>
+            エネルギッシュなビジュアルと言葉で、Gaia LLC の価値創造を大胆に伝えるプレゼンテーション。視覚的なストーリーテリングで、ブランドの芯を強く印象づけます。
+          </p>
+          <div class="cta-group">
+            <a class="button primary" href="#value-creation">価値創造を体感</a>
+            <a class="button secondary" href="#mission">ミッションを見る</a>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="assets/images/bold-hero-architecture.jpg" alt="ダイナミックな建築と自然が融合したビジュアル" />
+        </div>
+      </div>
+    </header>
+    <main id="main" class="container">
+      <section id="value-creation" class="section" aria-labelledby="value-title">
+        <div class="section-header">
+          <h2 id="value-title">VALUE CREATION｜価値創造</h2>
+          <p>感性と戦略を掛け合わせた 7 つのビジネスドライバー。</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>不動産事業</h3>
+            <p>都市開発から別荘地まで、確かな目利きで資産価値を最大化。</p>
+            <img src="assets/images/bold-realestate.jpg" alt="ハイコントラストな高層ビル群" />
+          </article>
+          <article class="card">
+            <h3>建築設計</h3>
+            <p>工事設計の現場感とクリエイティブな発想で空間体験を刷新。</p>
+            <img src="assets/images/bold-architecture.jpg" alt="大胆なラインが特徴的な建築設計図" />
+          </article>
+          <article class="card">
+            <h3>広告看板</h3>
+            <p>ストリートサイドで視線を奪う、唯一無二のビジュアルコミュニケーション。</p>
+            <img src="assets/images/bold-signage.jpg" alt="鮮烈な色彩で彩られた大型看板" />
+          </article>
+        </div>
+      </section>
+
+      <section id="services" class="section" aria-labelledby="service-title">
+        <div class="section-header">
+          <h2 id="service-title">Gaia LLC の事業領域</h2>
+          <p>多様な領域が連携し、唯一無二の価値提案を形にします。</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <ul class="list" aria-label="Gaia LLC の事業一覧">
+              <li><span aria-hidden="true">•</span>不動産事業・不動産コンサルティング</li>
+              <li><span aria-hidden="true">•</span>建築の工事設計</li>
+              <li><span aria-hidden="true">•</span>広告看板・ストリートサイド広告</li>
+              <li><span aria-hidden="true">•</span>生命保険募集・損害保険代理店</li>
+              <li><span aria-hidden="true">•</span>住宅地・別荘地の開発造成</li>
+            </ul>
+          </div>
+          <div>
+            <img src="assets/images/bold-collage.jpg" alt="建築、看板、保険相談の写真を重ねたダイナミックなコラージュ" />
+          </div>
+        </div>
+      </section>
+
+      <section id="company" class="section" aria-labelledby="company-title">
+        <div class="section-header">
+          <h2 id="company-title">Company Highlights</h2>
+          <p>熊本から全国へ、Gaia LLC が届ける価値をビジュアルで訴求。</p>
+        </div>
+        <div class="grid two">
+          <div class="card">
+            <h3>会社情報</h3>
+            <div class="fact"><span>社名</span>Gaiya LLC（合同会社ガイア）</div>
+            <div class="fact"><span>資本金</span>200万円</div>
+            <div class="fact"><span>所在地</span>熊本県熊本市中央区帯山５丁目３８番２５号</div>
+            <div class="fact"><span>設立</span>平成25年11月1日</div>
+            <div class="fact"><span>法人番号</span>5330003005421</div>
+          </div>
+          <div class="card">
+            <h3>ローカルスピリット</h3>
+            <p>地域とともに歩む姿勢を前面に、未来志向のビジョンを描きます。</p>
+            <img src="assets/images/bold-kumamoto.jpg" alt="熊本の自然と街並みをドラマチックに切り取った写真" />
+          </div>
+        </div>
+      </section>
+
+      <section id="presentation" class="section" aria-labelledby="presentation-title">
+        <div class="section-header">
+          <h2 id="presentation-title">プレゼンテーション・ストーリー</h2>
+          <p>Gaia LLC のクリエイティブ DNA を体感する、ダイナミックな 3 つの章。</p>
+        </div>
+        <div class="grid three">
+          <article class="card">
+            <h3>陶芸 Design × Place</h3>
+            <p>土と炎が生み出す唯一無二の造形で、空間体験を高めます。</p>
+            <img src="assets/images/bold-ceramics.jpg" alt="炎の前で焼成される陶器作品" />
+          </article>
+          <article class="card">
+            <h3>Creation</h3>
+            <p>自由な発想とチームの熱量で、次世代の価値を共創。</p>
+            <img src="assets/images/bold-creation-team.jpg" alt="色彩豊かなメモを壁に貼り議論するチーム" />
+          </article>
+          <article class="card">
+            <h3>Signboard Business</h3>
+            <p>街の風景を劇場に変える、圧倒的なビジュアルプレゼンス。</p>
+            <img src="assets/images/bold-street-sign.jpg" alt="鮮やかなライトに照らされたストリートサイン" />
+          </article>
+        </div>
+      </section>
+
+      <section id="message" class="section" aria-labelledby="message-title">
+        <div class="section-header">
+          <h2 id="message-title">Message</h2>
+          <p>情熱的な言葉で語る Gaia LLC の約束。</p>
+        </div>
+        <div class="message">
+          <p>
+            私たちの使命は「価値を創造し、社会に還元すること」。期待を超えるアイデアと行動で、地域と世界をつなぎます。
+          </p>
+          <p>
+            本質を問い続け、ユーザーと未来に向き合うことで、持続可能な社会への貢献を約束します。
+          </p>
+          <p>代表社員 井上真意</p>
+        </div>
+      </section>
+
+      <section id="mission" class="section" aria-labelledby="mission-title">
+        <div class="section-header">
+          <h2 id="mission-title">Mission</h2>
+          <p>価値を形にするハイインパクトなチーム。</p>
+        </div>
+        <div class="grid two">
+          <div>
+            <p>独自ネットワークと専門知識を掛け合わせ、リアルとデジタルの境界を超えて価値を実装します。</p>
+            <a class="button primary" href="#services">事業連携を見る</a>
+          </div>
+          <div>
+            <img src="assets/images/bold-mission-team.jpg" alt="力強い表情でプロジェクトを進めるチームメンバー" />
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer class="container">
+      <p>© Gaia LLC — Bold &amp; Immersive Storytelling</p>
+    </footer>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,60 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tablists = document.querySelectorAll('[role="tablist"]');
+
+  tablists.forEach((tablist) => {
+    const tabs = tablist.querySelectorAll('[role="tab"]');
+    const panels = document.querySelectorAll('[role="tabpanel"]');
+
+    function activateTab(tab) {
+      const targetId = tab.getAttribute('aria-controls');
+
+      tabs.forEach((t) => {
+        const isSelected = t === tab;
+        t.setAttribute('aria-selected', isSelected);
+        t.setAttribute('tabindex', isSelected ? '0' : '-1');
+      });
+
+      panels.forEach((panel) => {
+        const isMatch = panel.id === targetId;
+        panel.hidden = !isMatch;
+        panel.setAttribute('aria-hidden', String(!isMatch));
+      });
+
+      tab.focus();
+    }
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        activateTab(tab);
+      });
+
+      tab.addEventListener('keydown', (event) => {
+        const currentIndex = Array.from(tabs).indexOf(tab);
+        let newIndex = currentIndex;
+
+        if (event.key === 'ArrowRight') {
+          newIndex = (currentIndex + 1) % tabs.length;
+          event.preventDefault();
+        } else if (event.key === 'ArrowLeft') {
+          newIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+          event.preventDefault();
+        } else if (event.key === 'Home') {
+          newIndex = 0;
+          event.preventDefault();
+        } else if (event.key === 'End') {
+          newIndex = tabs.length - 1;
+          event.preventDefault();
+        }
+
+        if (newIndex !== currentIndex) {
+          activateTab(tabs[newIndex]);
+        }
+      });
+    });
+
+    const initiallySelected = tablist.querySelector('[role="tab"][aria-selected="true"]');
+    if (!initiallySelected && tabs.length) {
+      activateTab(tabs[0]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add tabbed index overview that previews three Gaia LLC design patterns with accessible keyboard support
- implement shared styling system with Atlassian-inspired spacing, typography, and responsive layouts across themes
- build individual modern minimal, dark gradient, and bold visual pattern pages each featuring hero imagery, business content, and CTA sections

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68cbd11913148331997a14c219feec5d