### PR TITLE
Add tri-theme Gaia LLC corporate overview site

### DIFF
--- a/images.manifest.json
+++ b/images.manifest.json
@@ -1,0 +1,113 @@
+{
+  "companyProfile": {
+    "name": "Gaia LLC",
+    "industry": [
+      "Real estate",
+      "Architectural design",
+      "Signboard advertising",
+      "Insurance agency",
+      "Land development"
+    ],
+    "valueProps": [
+      "Design × Place integration",
+      "Unique street-side media mix",
+      "Consultative asset strategy",
+      "Value creation for community"
+    ],
+    "audience": [
+      "Property owners",
+      "Investors",
+      "Local communities",
+      "Advertisers"
+    ],
+    "mission": "Create optimal value for clients and return it to society while staying future-oriented.",
+    "colors": [
+      "#1f4a3f",
+      "#2f5f92",
+      "#47f0bf",
+      "#d9772f",
+      "#6fb1c4"
+    ],
+    "keywords": [
+      "Design × Place",
+      "Value creation",
+      "Media mix",
+      "Pottery inspiration",
+      "Land development"
+    ]
+  },
+  "images": [
+    {
+      "file": "images/hero-1.svg",
+      "type": "hero",
+      "theme": "Modern minimal skyline network",
+      "source": {
+        "type": "generated",
+        "method": "hand-coded-svg",
+        "prompt": "Abstract skyline with network nodes in soft earth and teal gradients representing integrated real estate consulting"
+      },
+      "alt": "抽象的な都市ネットワークのビジュアル",
+      "licenseNote": "Custom vector illustration created for Gaia LLC concept."
+    },
+    {
+      "file": "images/hero-2.svg",
+      "type": "hero",
+      "theme": "Dark neon signage ribbons",
+      "source": {
+        "type": "generated",
+        "method": "hand-coded-svg",
+        "prompt": "Luminous neon ribbons over dark skyline evoking bespoke signboard advertising"
+      },
+      "alt": "ネオンが流れる街の抽象ビジュアル",
+      "licenseNote": "Custom vector illustration created for Gaia LLC concept."
+    },
+    {
+      "file": "images/hero-3.svg",
+      "type": "hero",
+      "theme": "Layered earth and clay landscape",
+      "source": {
+        "type": "generated",
+        "method": "hand-coded-svg",
+        "prompt": "Organic layered earth, clay, greenery and water forms referencing pottery craftsmanship and land creation"
+      },
+      "alt": "大地のレイヤーを思わせる有機的なグラデーション",
+      "licenseNote": "Custom vector illustration created for Gaia LLC concept."
+    },
+    {
+      "file": "images/section-1.svg",
+      "type": "section",
+      "theme": "Property planning grid",
+      "source": {
+        "type": "generated",
+        "method": "hand-coded-svg",
+        "prompt": "Minimal grid with modular blocks in teal and blue referencing property development planning"
+      },
+      "alt": "不動産開発のためのグリッドプランニング図",
+      "licenseNote": "Custom vector illustration created for Gaia LLC concept."
+    },
+    {
+      "file": "images/section-2.svg",
+      "type": "section",
+      "theme": "Neon media mix pathways",
+      "source": {
+        "type": "generated",
+        "method": "hand-coded-svg",
+        "prompt": "Neon light trails and signage panels symbolizing street-side advertising"
+      },
+      "alt": "ネオンサインの光跡と広告パネル",
+      "licenseNote": "Custom vector illustration created for Gaia LLC concept."
+    },
+    {
+      "file": "images/section-3.svg",
+      "type": "section",
+      "theme": "Clay growth rings",
+      "source": {
+        "type": "generated",
+        "method": "hand-coded-svg",
+        "prompt": "Bold clay rings with sprouting growth illustrating pottery aesthetics and land formation"
+      },
+      "alt": "陶芸と大地造成を象徴する重なるリング",
+      "licenseNote": "Custom vector illustration created for Gaia LLC concept."
+    }
+  ]
+}

--- a/images/hero-1.svg
+++ b/images/hero-1.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Networked architectural skyline abstract</title>
+  <desc id="desc">Abstract gradient cityscape with interconnected lines symbolizing Gaia LLC's integrated real estate and design services.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb" />
+      <stop offset="50%" stop-color="#eef3f1" />
+      <stop offset="100%" stop-color="#d8e7dd" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4a8f6d" />
+      <stop offset="100%" stop-color="#9ac78d" />
+    </linearGradient>
+    <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2f5f92" />
+      <stop offset="100%" stop-color="#8fc7d9" />
+    </linearGradient>
+    <clipPath id="cityClip">
+      <rect x="0" y="360" width="1440" height="540" rx="40" />
+    </clipPath>
+    <radialGradient id="node" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#3a7a5b" stop-opacity="0.3" />
+    </radialGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#sky)" />
+  <g clip-path="url(#cityClip)">
+    <rect x="0" y="360" width="1440" height="540" fill="#ffffff" fill-opacity="0.65" />
+    <g stroke="#a4b8ad" stroke-width="4" fill="none" stroke-linecap="round">
+      <path d="M120 860 V520" />
+      <path d="M220 860 V560" />
+      <path d="M340 860 V500" />
+      <path d="M420 860 V620" />
+      <path d="M540 860 V540" />
+      <path d="M660 860 V480" />
+      <path d="M780 860 V600" />
+      <path d="M900 860 V520" />
+      <path d="M1020 860 V560" />
+      <path d="M1140 860 V480" />
+      <path d="M1260 860 V580" />
+    </g>
+    <g stroke="url(#accentLine)" stroke-width="6" fill="none" stroke-linecap="round">
+      <path d="M160 600 L340 520 L520 620 L720 500 L940 580 L1180 520" />
+      <path d="M200 700 L420 620 L600 720 L860 600 L1100 660" opacity="0.6" />
+    </g>
+    <g fill="url(#node)">
+      <circle cx="160" cy="600" r="16" />
+      <circle cx="340" cy="520" r="18" />
+      <circle cx="520" cy="620" r="18" />
+      <circle cx="720" cy="500" r="20" />
+      <circle cx="940" cy="580" r="18" />
+      <circle cx="1180" cy="520" r="16" />
+    </g>
+    <rect x="80" y="560" width="160" height="300" fill="url(#accent)" opacity="0.65" />
+    <rect x="280" y="520" width="220" height="340" fill="url(#accent)" opacity="0.55" />
+    <rect x="560" y="500" width="180" height="360" fill="url(#accent)" opacity="0.5" />
+    <rect x="780" y="540" width="200" height="320" fill="url(#accent)" opacity="0.6" />
+    <rect x="1040" y="520" width="240" height="340" fill="url(#accent)" opacity="0.45" />
+  </g>
+  <path d="M0 300 C240 200 480 180 720 300 C960 420 1200 400 1440 260 L1440 900 L0 900 Z" fill="url(#accent)" opacity="0.18" />
+</svg>

--- a/images/hero-2.svg
+++ b/images/hero-2.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Luminous signage gradient landscape</title>
+  <desc id="desc">Dark gradient city backdrop with glowing signage-inspired ribbons representing Gaia LLC's bespoke signboard and media mix services.</desc>
+  <defs>
+    <linearGradient id="night" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#050914" />
+      <stop offset="100%" stop-color="#1d2539" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#f8ffdb" stop-opacity="0.9" />
+      <stop offset="40%" stop-color="#d3ff8a" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#4bd6c2" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="ribbonA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#48f0c0" />
+      <stop offset="50%" stop-color="#51a7ff" />
+      <stop offset="100%" stop-color="#c96bff" />
+    </linearGradient>
+    <linearGradient id="ribbonB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff8a5b" />
+      <stop offset="100%" stop-color="#ffd46b" />
+    </linearGradient>
+    <filter id="glowBlur" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="20" />
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#night)" />
+  <circle cx="360" cy="220" r="260" fill="url(#glow)" />
+  <circle cx="1080" cy="240" r="220" fill="url(#glow)" opacity="0.8" />
+  <g opacity="0.4" fill="#0f1626">
+    <path d="M140 720 h80 v120 h-80z" />
+    <path d="M280 660 h120 v180 h-120z" />
+    <path d="M460 700 h90 v140 h-90z" />
+    <path d="M620 620 h140 v220 h-140z" />
+    <path d="M820 660 h110 v180 h-110z" />
+    <path d="M980 700 h100 v140 h-100z" />
+    <path d="M1140 640 h140 v200 h-140z" />
+  </g>
+  <path d="M-80 640 C200 520 360 620 600 560 C860 494 960 640 1200 560 C1380 500 1520 600 1580 560" stroke="url(#ribbonA)" stroke-width="120" stroke-linecap="round" fill="none" opacity="0.6" filter="url(#glowBlur)" />
+  <path d="M-60 720 C200 620 420 760 680 640 C860 560 1060 700 1360 600" stroke="url(#ribbonB)" stroke-width="80" stroke-linecap="round" fill="none" opacity="0.8" filter="url(#glowBlur)" />
+  <path d="M-40 780 C200 720 480 820 740 720 C980 630 1160 760 1480 640" stroke="url(#ribbonA)" stroke-width="60" stroke-linecap="round" fill="none" opacity="0.6" />
+</svg>

--- a/images/hero-3.svg
+++ b/images/hero-3.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Layered earth and clay landscape</title>
+  <desc id="desc">Bold organic waves in earthen hues symbolizing Gaia LLC's craftsmanship, pottery inspiration, and land development vision.</desc>
+  <defs>
+    <linearGradient id="dawn" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffe8d9" />
+      <stop offset="50%" stop-color="#ffd1a8" />
+      <stop offset="100%" stop-color="#f6b17a" />
+    </linearGradient>
+    <linearGradient id="earth" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5c3a24" />
+      <stop offset="100%" stop-color="#a3683a" />
+    </linearGradient>
+    <linearGradient id="leaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3a7a3f" />
+      <stop offset="100%" stop-color="#8cc46a" />
+    </linearGradient>
+    <linearGradient id="river" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2b5c81" />
+      <stop offset="100%" stop-color="#6fb1c4" />
+    </linearGradient>
+    <pattern id="texture" patternUnits="userSpaceOnUse" width="40" height="40">
+      <circle cx="6" cy="6" r="2" fill="#f7c79d" opacity="0.4" />
+      <circle cx="26" cy="16" r="3" fill="#e4a46f" opacity="0.3" />
+      <circle cx="14" cy="30" r="2" fill="#f3b680" opacity="0.4" />
+      <circle cx="34" cy="34" r="1.5" fill="#e7a66f" opacity="0.4" />
+    </pattern>
+  </defs>
+  <rect width="1440" height="900" fill="url(#dawn)" />
+  <path d="M0 620 C180 540 280 520 420 580 C600 660 760 520 940 540 C1080 556 1240 640 1440 540 L1440 900 H0 Z" fill="url(#earth)" opacity="0.92" />
+  <path d="M0 520 C220 500 380 420 560 500 C740 580 1000 440 1240 480 C1340 498 1440 460 1440 460 L1440 900 0 900 Z" fill="url(#texture)" opacity="0.6" />
+  <path d="M0 420 C140 440 360 360 520 420 C720 498 900 360 1120 420 C1280 466 1440 400 1440 400 L1440 900 0 900 Z" fill="url(#leaf)" opacity="0.75" />
+  <path d="M0 320 C240 360 480 260 720 360 C960 460 1200 280 1440 360 L1440 900 0 900 Z" fill="url(#river)" opacity="0.55" />
+  <g fill="#ffffff" opacity="0.4">
+    <circle cx="240" cy="160" r="36" />
+    <circle cx="360" cy="200" r="22" />
+    <circle cx="520" cy="140" r="28" />
+    <circle cx="760" cy="180" r="24" />
+    <circle cx="980" cy="140" r="30" />
+    <circle cx="1180" cy="200" r="26" />
+  </g>
+</svg>

--- a/images/section-1.svg
+++ b/images/section-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Modular property planning grid</title>
+  <desc id="desc">Geometric grid with organic highlights representing Gaia LLC's property development planning and tailored consulting.</desc>
+  <defs>
+    <linearGradient id="gridBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8faf5" />
+      <stop offset="100%" stop-color="#e1efe5" />
+    </linearGradient>
+    <linearGradient id="gridAccent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2f5f92" />
+      <stop offset="100%" stop-color="#6bb896" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#gridBg)" />
+  <g stroke="#c8d7cc" stroke-width="2">
+    <path d="M80 120 H720" />
+    <path d="M80 220 H720" />
+    <path d="M80 320 H720" />
+    <path d="M80 420 H720" />
+    <path d="M80 520 H720" />
+    <path d="M180 60 V540" />
+    <path d="M300 60 V540" />
+    <path d="M440 60 V540" />
+    <path d="M580 60 V540" />
+    <path d="M700 60 V540" />
+  </g>
+  <rect x="180" y="220" width="120" height="200" rx="20" fill="url(#gridAccent)" opacity="0.75" />
+  <rect x="340" y="160" width="140" height="260" rx="24" fill="url(#gridAccent)" opacity="0.5" />
+  <rect x="520" y="260" width="120" height="160" rx="24" fill="url(#gridAccent)" opacity="0.65" />
+  <circle cx="260" cy="220" r="16" fill="#ffffff" opacity="0.9" />
+  <circle cx="410" cy="160" r="18" fill="#ffffff" opacity="0.8" />
+  <circle cx="580" cy="260" r="18" fill="#ffffff" opacity="0.8" />
+</svg>

--- a/images/section-2.svg
+++ b/images/section-2.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Neon media mix pathways</title>
+  <desc id="desc">Curved neon trails and signage panels symbolizing Gaia LLC's unique street-side advertising experiences.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1223" />
+      <stop offset="100%" stop-color="#1c1f3a" />
+    </linearGradient>
+    <linearGradient id="trailA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#47f0bf" />
+      <stop offset="100%" stop-color="#5aa7ff" />
+    </linearGradient>
+    <linearGradient id="trailB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff8a5b" />
+      <stop offset="100%" stop-color="#ffd46b" />
+    </linearGradient>
+    <filter id="blur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14" />
+    </filter>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)" />
+  <path d="M-40 480 C140 400 320 560 500 440 C640 360 720 480 860 420" stroke="url(#trailA)" stroke-width="80" fill="none" opacity="0.5" filter="url(#blur)" />
+  <path d="M-80 380 C160 300 360 460 520 340 C660 240 760 340 880 300" stroke="url(#trailB)" stroke-width="60" fill="none" opacity="0.7" filter="url(#blur)" />
+  <path d="M-20 520 C220 460 360 520 560 420 C720 340 800 420 920 360" stroke="url(#trailA)" stroke-width="40" fill="none" opacity="0.6" />
+  <g fill="#0f1626" opacity="0.9">
+    <rect x="140" y="160" width="140" height="220" rx="18" />
+    <rect x="340" y="120" width="160" height="260" rx="18" />
+    <rect x="560" y="180" width="130" height="200" rx="18" />
+  </g>
+  <g fill="#e8ffd7" opacity="0.8">
+    <rect x="160" y="200" width="100" height="60" rx="12" />
+    <rect x="360" y="160" width="120" height="70" rx="12" />
+    <rect x="580" y="220" width="90" height="60" rx="12" />
+  </g>
+</svg>

--- a/images/section-3.svg
+++ b/images/section-3.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Crafted clay layers and growth</title>
+  <desc id="desc">Dynamic clay rings and sprouting lines reflecting Gaia LLC's pottery aesthetic and sustainable land creation.</desc>
+  <defs>
+    <linearGradient id="warm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6b17a" />
+      <stop offset="100%" stop-color="#d9772f" />
+    </linearGradient>
+    <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3a7a3f" />
+      <stop offset="100%" stop-color="#9bd07c" />
+    </linearGradient>
+    <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2b5c81" />
+      <stop offset="100%" stop-color="#6fb1c4" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="#fff1e7" />
+  <g fill="none" stroke="url(#warm)" stroke-width="32" opacity="0.7">
+    <path d="M120 480 C220 360 360 520 480 400 C560 320 660 360 700 320" />
+  </g>
+  <g fill="none" stroke="url(#green)" stroke-width="24" opacity="0.75">
+    <path d="M80 420 C200 340 340 420 460 320 C560 240 680 280 760 200" />
+  </g>
+  <g fill="none" stroke="url(#blue)" stroke-width="20" opacity="0.6">
+    <path d="M60 360 C200 280 320 360 460 260 C600 160 700 220 820 120" />
+  </g>
+  <g fill="#fbe0c5" opacity="0.8">
+    <circle cx="220" cy="320" r="60" />
+    <circle cx="420" cy="240" r="46" />
+    <circle cx="600" cy="200" r="52" />
+  </g>
+  <g stroke="#35683a" stroke-width="6" stroke-linecap="round">
+    <path d="M220 320 L220 200" />
+    <path d="M420 240 L420 140" />
+    <path d="M600 200 L600 120" />
+  </g>
+  <g fill="#35683a">
+    <path d="M220 200 l-18 -24 18 8 18 -8z" />
+    <path d="M420 140 l-18 -24 18 8 18 -8z" />
+    <path d="M600 120 l-18 -24 18 8 18 -8z" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gaia LLC Corporate Design Variations</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="brand">
+        <h1>Gaia LLC</h1>
+        <span>価値創造 × Design × Place</span>
+      </div>
+      <div class="tablist" role="tablist" aria-label="デザインテーマ">
+        <button id="tab-pattern-1" role="tab" aria-controls="panel-pattern-1" aria-selected="true">モダンミニマル</button>
+        <button id="tab-pattern-2" role="tab" aria-controls="panel-pattern-2" aria-selected="false">ダーク×グラデーション</button>
+        <button id="tab-pattern-3" role="tab" aria-controls="panel-pattern-3" aria-selected="false">ビジュアルリッチ</button>
+      </div>
+    </header>
+    <main>
+      <section class="pattern-1" aria-labelledby="tab-pattern-1" role="tabpanel" id="panel-pattern-1">
+        <!-- industry=Real estate & consulting → grid skyline motif, colors=earthy green/blue from Gaia naming -->
+        <article class="hero">
+          <div class="hero-content">
+            <h2>Gaia LLC Value Canvas</h2>
+            <p><strong>Design × Place</strong> を掲げ、不動産・建築・広告の専門知識を統合したソリューションで、土地・空間・街並みの価値を最大化します。</p>
+            <p>地域社会と投資家の双方に寄り添いながら、感性とデータの両面でプロジェクトを導くモダンミニマルなコーポレートストーリー。</p>
+            <div class="cta">
+              <a class="primary" href="#contact">相談する</a>
+              <a class="secondary" href="#mission">ミッションを見る</a>
+            </div>
+          </div>
+          <img src="images/hero-1.svg" alt="抽象的な都市ネットワークのビジュアル" loading="lazy" />
+        </article>
+
+        <section class="features" aria-label="Gaia LLCのシナジー領域">
+          <article class="feature-card">
+            <!-- industry=Real estate development → modular planning grid, value=consulting -->
+            <img src="images/section-1.svg" alt="不動産開発のためのグリッドプランニング図" loading="lazy" />
+            <h3>土地活用と開発設計</h3>
+            <p>住宅地・別荘地から都市開発まで、地質や地域特性に合わせたマスタープランニングで資産の潜在価値を引き出します。</p>
+          </article>
+          <article class="feature-card">
+            <h3>不動産コンサルティング</h3>
+            <p>独自ネットワークとデータ分析で、賃貸・投資・保険までワンストップで最適化。顧客の長期的な資産戦略を共創します。</p>
+          </article>
+          <article class="feature-card">
+            <h3>地域と共に築くブランド</h3>
+            <p>熊本を起点に、街並みや文化を尊重した建築・看板デザインで地域価値を高め、持続可能な社会へと還元します。</p>
+          </article>
+        </section>
+
+        <section id="mission" class="features" aria-label="Gaia LLCのメッセージ">
+          <article class="feature-card">
+            <h3>価値創造へのコミットメント</h3>
+            <blockquote>
+              私たちの使命は「価値を創造し、社会に還元すること」。ユーザー視点と未来志向で新たな価値を形にします。
+            </blockquote>
+          </article>
+          <article class="feature-card">
+            <h3>社会との共創</h3>
+            <p>お客様・パートナー・地域社会との結びつきを大切に、共に成長するエコシステムを築くことで、価値創造を連鎖させます。</p>
+          </article>
+        </section>
+
+        <section class="data-grid" aria-label="会社概要">
+          <div>
+            <h4>業種</h4>
+            <p>不動産事業／建築工事設計／広告看板／保険代理店／不動産コンサル／土地開発</p>
+          </div>
+          <div>
+            <h4>会社情報</h4>
+            <p>熊本県熊本市中央区帯山５丁目３８番２５号<br />資本金：200万円／設立：2013年11月1日</p>
+          </div>
+          <div>
+            <h4>法人番号</h4>
+            <p>5330003005421</p>
+          </div>
+        </section>
+
+        <footer>
+          <p>© Gaia LLC. Value creation for place, community, and future.</p>
+        </footer>
+      </section>
+
+      <section class="pattern-2" aria-labelledby="tab-pattern-2" role="tabpanel" id="panel-pattern-2" hidden>
+        <!-- industry=Signboard & media mix → neon ribbon motif, colors=teal/orange gradient echoing illuminated signage -->
+        <article class="hero">
+          <div class="hero-content">
+            <h2>Street Impact Studio</h2>
+            <p>デジタルでは再現できないストリートサイド広告の熱量を、Gaia LLCのクリエイティブで立体化。土地条件から法規制までを読み解き、唯一無二のメディア体験を設計します。</p>
+            <p>夜空に浮かぶネオンサインを想起させるトーンで、ブランドと都市の出会いをドラマティックに。</p>
+            <div class="cta">
+              <a class="primary" href="#contact">制作を依頼</a>
+              <a class="secondary" href="#cases">導入事例</a>
+            </div>
+          </div>
+          <img src="images/hero-2.svg" alt="ネオンが流れる街の抽象ビジュアル" loading="lazy" />
+        </article>
+
+        <section class="features" id="cases" aria-label="広告クリエイティブ領域">
+          <article class="feature-card">
+            <!-- industry=Signboard business → neon media mix pathways -->
+            <img src="images/section-2.svg" alt="ネオンサインの光跡と広告パネル" loading="lazy" />
+            <h3>メディアミックス設計</h3>
+            <p>街路・建物・歩行者導線を解析し、アナログ×デジタルを組み合わせた広告導線を構築します。</p>
+          </article>
+          <article class="feature-card">
+            <h3>ブランドモーション</h3>
+            <p>光と素材を活かした看板演出で、夜間でも視認性とブランドの世界観を両立。地域景観と調和する色彩計画を実施します。</p>
+          </article>
+          <article class="feature-card">
+            <h3>価値保証と保険サポート</h3>
+            <p>生命保険・損害保険の知見を活かし、設置から運用までのリスクマネジメントをカバー。事業継続性を守ります。</p>
+          </article>
+        </section>
+
+        <section class="features" aria-label="Gaia LLCのメッセージ">
+          <article class="feature-card">
+            <h3>自由な創造力</h3>
+            <p>陶芸で培った「素材を活かす」発想を広告デザインへ。光・風・時間に合わせて変化するサインで、観る人の感性に訴えます。</p>
+          </article>
+          <article class="feature-card">
+            <h3>地域共創コミュニティ</h3>
+            <p>自治体・企業・住民と共に街の魅力を再編集し、持続可能な広告エコシステムを育てます。</p>
+          </article>
+        </section>
+
+        <section class="data-grid" aria-label="会社情報">
+          <div>
+            <h4>拠点</h4>
+            <p>熊本県熊本市中央区帯山５丁目３８番２５号</p>
+          </div>
+          <div>
+            <h4>キーワード</h4>
+            <p>Signboard Business／Media Mix／Design × Place</p>
+          </div>
+          <div>
+            <h4>価値</h4>
+            <p>独自性・自由な創造力・社会還元</p>
+          </div>
+        </section>
+
+        <footer>
+          <p>© Gaia LLC. Bespoke street-side storytelling crafted with light.</p>
+        </footer>
+      </section>
+
+      <section class="pattern-3" aria-labelledby="tab-pattern-3" role="tabpanel" id="panel-pattern-3" hidden>
+        <!-- industry=Land development & pottery inspiration → layered earth motif, colors=terracotta/green/blue from mission of sustainable growth -->
+        <article class="hero">
+          <div class="hero-content">
+            <h2>Gaia Crafted Futures</h2>
+            <p>陶芸の「練り込み」と土地造成のレイヤーを重ね合わせ、感性と価値の裏付けをサービスへと変換。人と自然、都市が共鳴する開発ストーリーを大胆なビジュアルで表現します。</p>
+            <p>地球を意味するGaiaの名のもと、土・緑・水のトーンで持続可能な街づくりを描きます。</p>
+            <div class="cta">
+              <a class="primary" href="#projects">プロジェクトを見る</a>
+              <a class="secondary" href="#message">メッセージ</a>
+            </div>
+          </div>
+          <img src="images/hero-3.svg" alt="大地のレイヤーを思わせる有機的なグラデーション" loading="lazy" />
+        </article>
+
+        <section class="features" id="projects" aria-label="Gaia LLCの事業領域">
+          <article class="feature-card">
+            <!-- industry=Land development & sustainability → layered clay growth motif -->
+            <img src="images/section-3.svg" alt="陶芸と大地造成を象徴する重なるリング" loading="lazy" />
+            <h3>土地造成と景観デザイン</h3>
+            <p>地形解析と環境配慮の両立で、住宅地・別荘地開発を高品質にプロデュース。自然素材を意識した景観づくりで長期価値を確保します。</p>
+          </article>
+          <article class="feature-card">
+            <h3>価値創造エコシステム</h3>
+            <p>不動産・保険・広告の知見をつなぎ、街全体の価値を引き上げるシナリオを構築。持続可能な投資循環を生み出します。</p>
+          </article>
+          <article class="feature-card" id="message">
+            <h3>代表メッセージ</h3>
+            <blockquote>
+              変化を恐れず挑戦を続け、持続可能な社会の実現に貢献します。皆様にとってなくてはならない存在であり続けるために。
+            </blockquote>
+            <p>代表社員　井上真意</p>
+          </article>
+        </section>
+
+        <section class="data-grid" aria-label="ブランドステートメント">
+          <div>
+            <h4>ミッション</h4>
+            <p>お客様にとって最適な価値を常に考え、提案し、形にする。</p>
+          </div>
+          <div>
+            <h4>バリュー</h4>
+            <p>価値創造／社会還元／自由な創造力</p>
+          </div>
+          <div>
+            <h4>サービス</h4>
+            <p>不動産事業・建築設計・看板広告・保険代理・コンサルティング</p>
+          </div>
+        </section>
+
+        <footer>
+          <p>© Gaia LLC. Crafting places where creativity takes root.</p>
+        </footer>
+      </section>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/pattern-1.html
+++ b/pattern-1.html
@@ -1,0 +1,64 @@
+<section class="pattern-1" aria-labelledby="tab-pattern-1" role="tabpanel" id="panel-pattern-1" hidden>
+  <!-- industry=Real estate & consulting → grid skyline motif, colors=earthy green/blue from Gaia naming -->
+  <article class="hero">
+    <div class="hero-content">
+      <h2>Gaia LLC Value Canvas</h2>
+      <p><strong>Design × Place</strong> を掲げ、不動産・建築・広告の専門知識を統合したソリューションで、土地・空間・街並みの価値を最大化します。</p>
+      <p>地域社会と投資家の双方に寄り添いながら、感性とデータの両面でプロジェクトを導くモダンミニマルなコーポレートストーリー。</p>
+      <div class="cta">
+        <a class="primary" href="#contact">相談する</a>
+        <a class="secondary" href="#mission">ミッションを見る</a>
+      </div>
+    </div>
+    <img src="images/hero-1.svg" alt="抽象的な都市ネットワークのビジュアル" loading="lazy" />
+  </article>
+
+  <section class="features" aria-label="Gaia LLCのシナジー領域">
+    <article class="feature-card">
+      <!-- industry=Real estate development → modular planning grid, value=consulting -->
+      <img src="images/section-1.svg" alt="不動産開発のためのグリッドプランニング図" loading="lazy" />
+      <h3>土地活用と開発設計</h3>
+      <p>住宅地・別荘地から都市開発まで、地質や地域特性に合わせたマスタープランニングで資産の潜在価値を引き出します。</p>
+    </article>
+    <article class="feature-card">
+      <h3>不動産コンサルティング</h3>
+      <p>独自ネットワークとデータ分析で、賃貸・投資・保険までワンストップで最適化。顧客の長期的な資産戦略を共創します。</p>
+    </article>
+    <article class="feature-card">
+      <h3>地域と共に築くブランド</h3>
+      <p>熊本を起点に、街並みや文化を尊重した建築・看板デザインで地域価値を高め、持続可能な社会へと還元します。</p>
+    </article>
+  </section>
+
+  <section id="mission" class="features" aria-label="Gaia LLCのメッセージ">
+    <article class="feature-card">
+      <h3>価値創造へのコミットメント</h3>
+      <blockquote>
+        私たちの使命は「価値を創造し、社会に還元すること」。ユーザー視点と未来志向で新たな価値を形にします。
+      </blockquote>
+    </article>
+    <article class="feature-card">
+      <h3>社会との共創</h3>
+      <p>お客様・パートナー・地域社会との結びつきを大切に、共に成長するエコシステムを築くことで、価値創造を連鎖させます。</p>
+    </article>
+  </section>
+
+  <section class="data-grid" aria-label="会社概要">
+    <div>
+      <h4>業種</h4>
+      <p>不動産事業／建築工事設計／広告看板／保険代理店／不動産コンサル／土地開発</p>
+    </div>
+    <div>
+      <h4>会社情報</h4>
+      <p>熊本県熊本市中央区帯山５丁目３８番２５号<br />資本金：200万円／設立：2013年11月1日</p>
+    </div>
+    <div>
+      <h4>法人番号</h4>
+      <p>5330003005421</p>
+    </div>
+  </section>
+
+  <footer>
+    <p>© Gaia LLC. Value creation for place, community, and future.</p>
+  </footer>
+</section>

--- a/pattern-2.html
+++ b/pattern-2.html
@@ -1,0 +1,62 @@
+<section class="pattern-2" aria-labelledby="tab-pattern-2" role="tabpanel" id="panel-pattern-2" hidden>
+  <!-- industry=Signboard & media mix → neon ribbon motif, colors=teal/orange gradient echoing illuminated signage -->
+  <article class="hero">
+    <div class="hero-content">
+      <h2>Street Impact Studio</h2>
+      <p>デジタルでは再現できないストリートサイド広告の熱量を、Gaia LLCのクリエイティブで立体化。土地条件から法規制までを読み解き、唯一無二のメディア体験を設計します。</p>
+      <p>夜空に浮かぶネオンサインを想起させるトーンで、ブランドと都市の出会いをドラマティックに。</p>
+      <div class="cta">
+        <a class="primary" href="#contact">制作を依頼</a>
+        <a class="secondary" href="#cases">導入事例</a>
+      </div>
+    </div>
+    <img src="images/hero-2.svg" alt="ネオンが流れる街の抽象ビジュアル" loading="lazy" />
+  </article>
+
+  <section class="features" id="cases" aria-label="広告クリエイティブ領域">
+    <article class="feature-card">
+      <!-- industry=Signboard business → neon media mix pathways -->
+      <img src="images/section-2.svg" alt="ネオンサインの光跡と広告パネル" loading="lazy" />
+      <h3>メディアミックス設計</h3>
+      <p>街路・建物・歩行者導線を解析し、アナログ×デジタルを組み合わせた広告導線を構築します。</p>
+    </article>
+    <article class="feature-card">
+      <h3>ブランドモーション</h3>
+      <p>光と素材を活かした看板演出で、夜間でも視認性とブランドの世界観を両立。地域景観と調和する色彩計画を実施します。</p>
+    </article>
+    <article class="feature-card">
+      <h3>価値保証と保険サポート</h3>
+      <p>生命保険・損害保険の知見を活かし、設置から運用までのリスクマネジメントをカバー。事業継続性を守ります。</p>
+    </article>
+  </section>
+
+  <section class="features" aria-label="Gaia LLCのメッセージ">
+    <article class="feature-card">
+      <h3>自由な創造力</h3>
+      <p>陶芸で培った「素材を活かす」発想を広告デザインへ。光・風・時間に合わせて変化するサインで、観る人の感性に訴えます。</p>
+    </article>
+    <article class="feature-card">
+      <h3>地域共創コミュニティ</h3>
+      <p>自治体・企業・住民と共に街の魅力を再編集し、持続可能な広告エコシステムを育てます。</p>
+    </article>
+  </section>
+
+  <section class="data-grid" aria-label="会社情報">
+    <div>
+      <h4>拠点</h4>
+      <p>熊本県熊本市中央区帯山５丁目３８番２５号</p>
+    </div>
+    <div>
+      <h4>キーワード</h4>
+      <p>Signboard Business／Media Mix／Design × Place</p>
+    </div>
+    <div>
+      <h4>価値</h4>
+      <p>独自性・自由な創造力・社会還元</p>
+    </div>
+  </section>
+
+  <footer>
+    <p>© Gaia LLC. Bespoke street-side storytelling crafted with light.</p>
+  </footer>
+</section>

--- a/pattern-3.html
+++ b/pattern-3.html
@@ -1,0 +1,54 @@
+<section class="pattern-3" aria-labelledby="tab-pattern-3" role="tabpanel" id="panel-pattern-3" hidden>
+  <!-- industry=Land development & pottery inspiration → layered earth motif, colors=terracotta/green/blue from mission of sustainable growth -->
+  <article class="hero">
+    <div class="hero-content">
+      <h2>Gaia Crafted Futures</h2>
+      <p>陶芸の「練り込み」と土地造成のレイヤーを重ね合わせ、感性と価値の裏付けをサービスへと変換。人と自然、都市が共鳴する開発ストーリーを大胆なビジュアルで表現します。</p>
+      <p>地球を意味するGaiaの名のもと、土・緑・水のトーンで持続可能な街づくりを描きます。</p>
+      <div class="cta">
+        <a class="primary" href="#projects">プロジェクトを見る</a>
+        <a class="secondary" href="#message">メッセージ</a>
+      </div>
+    </div>
+    <img src="images/hero-3.svg" alt="大地のレイヤーを思わせる有機的なグラデーション" loading="lazy" />
+  </article>
+
+  <section class="features" id="projects" aria-label="Gaia LLCの事業領域">
+    <article class="feature-card">
+      <!-- industry=Land development & sustainability → layered clay growth motif -->
+      <img src="images/section-3.svg" alt="陶芸と大地造成を象徴する重なるリング" loading="lazy" />
+      <h3>土地造成と景観デザイン</h3>
+      <p>地形解析と環境配慮の両立で、住宅地・別荘地開発を高品質にプロデュース。自然素材を意識した景観づくりで長期価値を確保します。</p>
+    </article>
+    <article class="feature-card">
+      <h3>価値創造エコシステム</h3>
+      <p>不動産・保険・広告の知見をつなぎ、街全体の価値を引き上げるシナリオを構築。持続可能な投資循環を生み出します。</p>
+    </article>
+    <article class="feature-card" id="message">
+      <h3>代表メッセージ</h3>
+      <blockquote>
+        変化を恐れず挑戦を続け、持続可能な社会の実現に貢献します。皆様にとってなくてはならない存在であり続けるために。
+      </blockquote>
+      <p>代表社員　井上真意</p>
+    </article>
+  </section>
+
+  <section class="data-grid" aria-label="ブランドステートメント">
+    <div>
+      <h4>ミッション</h4>
+      <p>お客様にとって最適な価値を常に考え、提案し、形にする。</p>
+    </div>
+    <div>
+      <h4>バリュー</h4>
+      <p>価値創造／社会還元／自由な創造力</p>
+    </div>
+    <div>
+      <h4>サービス</h4>
+      <p>不動産事業・建築設計・看板広告・保険代理・コンサルティング</p>
+    </div>
+  </section>
+
+  <footer>
+    <p>© Gaia LLC. Crafting places where creativity takes root.</p>
+  </footer>
+</section>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+  const panels = Array.from(document.querySelectorAll('[role="tabpanel"]'));
+
+  function activateTab(tab) {
+    tabs.forEach((btn) => {
+      const selected = btn === tab;
+      btn.setAttribute('aria-selected', String(selected));
+      btn.tabIndex = selected ? 0 : -1;
+    });
+
+    panels.forEach((panel) => {
+      if (panel.id === tab.getAttribute('aria-controls')) {
+        panel.hidden = false;
+      } else {
+        panel.hidden = true;
+      }
+    });
+
+    tab.focus();
+  }
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => activateTab(tab));
+    tab.addEventListener('keydown', (event) => {
+      const currentIndex = tabs.indexOf(tab);
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        const nextTab = tabs[(currentIndex + 1) % tabs.length];
+        activateTab(nextTab);
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        const prevTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+        activateTab(prevTab);
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        activateTab(tabs[0]);
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        activateTab(tabs[tabs.length - 1]);
+      }
+    });
+  });
+
+  const initialTab = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabs[0];
+  activateTab(initialTab);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,335 @@
+:root {
+  --transition-fast: 0.3s ease;
+  --font-body: "Segoe UI", "Hiragino Sans", "Noto Sans JP", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: #f5f7f8;
+  color: #1f2b2b;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
+}
+
+header {
+  padding: 1rem clamp(1rem, 4vw, 3rem);
+  background: #ffffff;
+  box-shadow: 0 2px 16px rgba(15, 32, 40, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.brand h1 {
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.brand span {
+  font-size: clamp(0.85rem, 1vw + 0.5rem, 1.1rem);
+  color: #4f6f67;
+}
+
+.tablist {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+}
+
+.tablist button {
+  border: none;
+  background: #e4ebe5;
+  color: #1f2b2b;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+  white-space: nowrap;
+}
+
+.tablist button[aria-selected="true"] {
+  background: #1f4a3f;
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(25, 74, 63, 0.28);
+}
+
+.tablist button:focus-visible {
+  outline: 3px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+main {
+  padding: clamp(1rem, 3vw, 3rem) clamp(1rem, 6vw, 5rem) 4rem;
+}
+
+section[role="tabpanel"] {
+  display: none;
+}
+
+section[role="tabpanel"]:not([hidden]) {
+  display: block;
+  animation: fadeIn 0.6s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero {
+  display: grid;
+  gap: clamp(1rem, 4vw, 3rem);
+  align-items: center;
+}
+
+.hero img,
+.hero svg {
+  width: 100%;
+  height: auto;
+  border-radius: clamp(1rem, 3vw, 1.75rem);
+  box-shadow: 0 20px 50px rgba(20, 50, 45, 0.12);
+}
+
+.hero-content h2 {
+  font-size: clamp(2.25rem, 4vw, 3.5rem);
+  margin: 0 0 1rem 0;
+}
+
+.hero-content p {
+  max-width: 50ch;
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+}
+
+.features {
+  display: grid;
+  gap: clamp(1rem, 3vw, 2rem);
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+}
+
+.feature-card {
+  background: #ffffff;
+  padding: clamp(1.25rem, 4vw, 2.5rem);
+  border-radius: 1.5rem;
+  box-shadow: 0 16px 32px rgba(11, 22, 18, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-card img,
+.feature-card svg {
+  width: 100%;
+  height: auto;
+  border-radius: 1rem;
+}
+
+.feature-card h3 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+}
+
+.pattern-1 {
+  color: #1b3a32;
+}
+
+.pattern-1 .hero {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.pattern-1 .hero-content p strong {
+  color: #1f5b4a;
+}
+
+.pattern-1 .feature-card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(233, 244, 236, 0.85));
+  border: 1px solid rgba(79, 111, 103, 0.2);
+}
+
+.pattern-2 {
+  background: radial-gradient(circle at top left, rgba(52, 93, 138, 0.25), transparent 60%), #050914;
+  color: #ecf8ff;
+}
+
+.pattern-2 .hero img,
+.pattern-2 .feature-card img,
+.pattern-2 .hero svg,
+.pattern-2 .feature-card svg {
+  box-shadow: 0 30px 60px rgba(7, 15, 32, 0.7);
+}
+
+.pattern-2 .hero {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.pattern-2 .feature-card {
+  background: linear-gradient(135deg, rgba(6, 14, 32, 0.9), rgba(41, 32, 78, 0.6));
+  border: 1px solid rgba(95, 244, 203, 0.3);
+}
+
+.pattern-2 .feature-card h3 {
+  color: #9fffd7;
+}
+
+.pattern-3 {
+  background: linear-gradient(180deg, #ffe8d9 0%, #fff5ed 100%);
+  color: #5c3a24;
+}
+
+.pattern-3 .hero {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.pattern-3 .hero-content h2 {
+  color: #a35b2f;
+}
+
+.pattern-3 .feature-card {
+  background: rgba(255, 242, 232, 0.92);
+  border: 1px solid rgba(163, 91, 47, 0.25);
+  box-shadow: 0 20px 40px rgba(163, 91, 47, 0.16);
+}
+
+.pattern-3 .feature-card h3 {
+  color: #3a7a3f;
+}
+
+blockquote {
+  margin: 0;
+  padding: 1.5rem 2rem;
+  border-left: 4px solid currentColor;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 1rem;
+  font-style: italic;
+}
+
+.data-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 2rem;
+}
+
+.data-grid div {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.pattern-2 .data-grid div {
+  background: rgba(12, 22, 44, 0.75);
+  border-color: rgba(95, 244, 203, 0.25);
+}
+
+.pattern-3 .data-grid div {
+  background: rgba(255, 242, 232, 0.82);
+  border-color: rgba(163, 91, 47, 0.18);
+}
+
+.cta {
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.cta a {
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.cta a.primary {
+  background: #1f4a3f;
+  color: #ffffff;
+  box-shadow: 0 18px 36px rgba(31, 74, 63, 0.25);
+}
+
+.cta a.secondary {
+  background: transparent;
+  color: inherit;
+  border: 2px solid currentColor;
+}
+
+.pattern-2 .cta a.primary {
+  background: linear-gradient(135deg, #47f0bf, #5aa7ff);
+  color: #05111f;
+}
+
+.pattern-3 .cta a.primary {
+  background: linear-gradient(135deg, #d9772f, #f6b17a);
+  color: #fffaf5;
+}
+
+.pattern-2 .cta a.secondary {
+  border-color: #9fffd7;
+}
+
+.pattern-3 .cta a.secondary {
+  border-color: #a35b2f;
+}
+
+footer {
+  padding: 3rem 1rem 1.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(31, 43, 43, 0.7);
+}
+
+.pattern-2 footer {
+  color: rgba(236, 248, 255, 0.65);
+}
+
+.pattern-3 footer {
+  color: rgba(92, 58, 36, 0.65);
+}
+
+@media (max-width: 768px) {
+  header {
+    position: static;
+  }
+
+  main {
+    padding: 1rem clamp(0.75rem, 6vw, 2rem) 3rem;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- create tabbed single-page index with three differentiated corporate overview layouts referencing Gaia LLC's mission and services
- add standalone pattern templates and responsive styling with accessible keyboard-controlled tab interactions
- craft generative SVG hero and section artwork aligned to real estate, signage, and land development narratives with manifest metadata

## Testing
- python -m json.tool images.manifest.json

------
https://chatgpt.com/codex/tasks/task_e_68cce68cb7948331a9e403ead9efda17