### PR TITLE
Add Gaia LLC multi-theme web concepts

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.nav-toggle');
+  const nav = document.querySelector('.nav');
+
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!expanded));
+      nav.classList.toggle('open');
+    });
+  }
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,355 @@
+:root {
+  color-scheme: light dark;
+  --brand-primary: #0052cc;
+  --brand-secondary: #36b37e;
+  --brand-accent: #f5a623;
+  --brand-dark: #0b1c34;
+  --brand-neutral: #f5f7fb;
+  --text-color: #1f2a44;
+  --text-muted: #4a5971;
+  --font-body: "Inter", "Noto Sans JP", "Hiragino Sans", "Segoe UI", sans-serif;
+  --font-display: "Manrope", "Noto Sans JP", "Hiragino Sans", "Segoe UI", sans-serif;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --shadow-soft: 0 20px 45px rgba(15, 35, 95, 0.08);
+  --shadow-strong: 0 30px 70px rgba(0, 0, 0, 0.25);
+  --max-width: 1080px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--text-color);
+  background: #ffffff;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+body.pattern-2 {
+  color: #f4f7ff;
+  background: radial-gradient(circle at 20% 20%, rgba(54, 179, 126, 0.2), transparent 50%),
+    radial-gradient(circle at 80% 0%, rgba(0, 82, 204, 0.4), transparent 60%),
+    #050910;
+}
+
+body.pattern-3 {
+  color: #102033;
+  background: linear-gradient(160deg, rgba(245, 166, 35, 0.12), rgba(0, 82, 204, 0.08)), #fdf9f3;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  backdrop-filter: blur(14px);
+  background-color: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid rgba(15, 35, 95, 0.08);
+}
+
+body.pattern-2 .site-header {
+  background-color: rgba(5, 9, 16, 0.9);
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
+body.pattern-3 .site-header {
+  background-color: rgba(253, 249, 243, 0.9);
+  border-bottom-color: rgba(16, 32, 51, 0.1);
+}
+
+nav[aria-label="Primary"] {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+}
+
+.brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.15rem;
+  text-decoration: none;
+  color: inherit;
+  letter-spacing: 0.06em;
+}
+
+.nav {
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav a {
+  text-decoration: none;
+  color: inherit;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: background-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
+}
+
+.nav a:focus-visible,
+.nav a:hover {
+  background-color: rgba(0, 82, 204, 0.12);
+  color: var(--brand-primary);
+}
+
+body.pattern-2 .nav a:focus-visible,
+body.pattern-2 .nav a:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 1px solid currentColor;
+  border-radius: 12px;
+  padding: 0.3rem 0.5rem;
+  color: inherit;
+}
+
+.nav-toggle:focus-visible {
+  outline: 3px solid var(--brand-accent);
+  outline-offset: 2px;
+}
+
+main {
+  padding: 6rem 1.5rem 3rem;
+}
+
+body.index main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 80px);
+  text-align: center;
+}
+
+.hero {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  padding: 3.5rem;
+  background: var(--brand-neutral);
+  box-shadow: var(--shadow-soft);
+}
+
+body.pattern-2 .hero {
+  background: linear-gradient(135deg, rgba(0, 82, 204, 0.45), rgba(54, 179, 126, 0.15));
+  box-shadow: var(--shadow-strong);
+}
+
+body.pattern-3 .hero {
+  background: #ffffff;
+  box-shadow: 0 40px 90px rgba(16, 32, 51, 0.16);
+}
+
+.hero-art {
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+}
+
+.hero-content {
+  align-self: center;
+}
+
+.hero-content h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 5vw, 3.8rem);
+  margin: 0 0 1rem;
+}
+
+.hero-content p.lead {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+  color: var(--text-muted);
+}
+
+body.pattern-2 .hero-content p.lead {
+  color: rgba(244, 247, 255, 0.76);
+}
+
+body.pattern-3 .hero-content p.lead {
+  color: #2d3e5c;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
+  box-shadow: 0 20px 40px rgba(0, 82, 204, 0.2);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 54px rgba(0, 82, 204, 0.3);
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 4rem auto;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.section:nth-of-type(even) .section-media {
+  order: 2;
+}
+
+.section h2 {
+  font-family: var(--font-display);
+  font-size: 2.2rem;
+  margin-bottom: 1rem;
+}
+
+.section p {
+  color: var(--text-muted);
+  margin: 0 0 1rem;
+}
+
+body.pattern-2 .section p {
+  color: rgba(244, 247, 255, 0.78);
+}
+
+.section-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.section-list li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.section-list li::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  margin-top: 0.35rem;
+  background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
+  flex-shrink: 0;
+}
+
+body.pattern-3 .section-list li::before {
+  background: linear-gradient(135deg, var(--brand-accent), var(--brand-primary));
+}
+
+.section-media {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+  background: rgba(255, 255, 255, 0.8);
+  padding: 1.5rem;
+}
+
+body.pattern-2 .section-media {
+  background: rgba(5, 9, 16, 0.7);
+  box-shadow: var(--shadow-strong);
+}
+
+body.pattern-3 .section-media {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 30px 70px rgba(16, 32, 51, 0.15);
+}
+
+.section-media svg {
+  width: 100%;
+  height: auto;
+}
+
+footer {
+  max-width: var(--max-width);
+  margin: 4rem auto 2rem;
+  padding: 2rem 1.5rem;
+  border-top: 1px solid rgba(15, 35, 95, 0.1);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+body.pattern-2 footer {
+  border-top-color: rgba(255, 255, 255, 0.14);
+  color: rgba(244, 247, 255, 0.65);
+}
+
+body.pattern-3 footer {
+  border-top-color: rgba(16, 32, 51, 0.18);
+  color: #2d3e5c;
+}
+
+@media (max-width: 768px) {
+  nav[aria-label="Primary"] {
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .nav {
+    flex-direction: column;
+    width: 100%;
+    display: none;
+    background: inherit;
+    padding-bottom: 0.75rem;
+  }
+
+  .nav.open {
+    display: flex;
+  }
+
+  .hero {
+    padding: 2.5rem 1.5rem;
+  }
+
+  main {
+    padding-top: 5.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}

--- a/images.manifest.json
+++ b/images.manifest.json
@@ -1,0 +1,86 @@
+[
+  {
+    "filename": "images/hero-1.svg",
+    "prompt": "Minimal geometric skyline with signage frames in Gaia LLC brand blue, green, and amber showing value creation beam",
+    "alt": "都市開発とサインボックスを組み合わせた抽象的な幾何学アート",
+    "usage": "pattern-1 hero",
+    "companyProfile": {
+      "industry": "Real estate development & signage design",
+      "valueProps": ["価値創造", "Design × Place", "独自看板最適化"],
+      "mission": "価値を創造し社会に還元",
+      "colors": ["#0052CC", "#36B37E", "#F5A623"]
+    },
+    "source": {"type": "generated", "url": ""},
+    "licenseNote": "Created as bespoke vector artwork for Gaia LLC branding."
+  },
+  {
+    "filename": "images/section-1.svg",
+    "prompt": "Line grid showing property parcels and flowing routes in blue, green, amber",
+    "alt": "都市区画と広告動線を示すグリッドと曲線のラインアート",
+    "usage": "pattern-1 services section",
+    "companyProfile": {
+      "industry": "Real estate & signage",
+      "valueProps": ["不動産コンサル", "看板設計"],
+      "mission": "価値を創造し社会に還元",
+      "colors": ["#0052CC", "#36B37E", "#F5A623"]
+    },
+    "source": {"type": "generated", "url": ""},
+    "licenseNote": "Created as bespoke vector artwork for Gaia LLC branding."
+  },
+  {
+    "filename": "images/hero-2.svg",
+    "prompt": "Dark gradient night city with neon light trails in Gaia colors for signage business",
+    "alt": "夜の街路に光の軌跡が走るネオングラデーションアート",
+    "usage": "pattern-2 hero",
+    "companyProfile": {
+      "industry": "Real estate, signage, insurance",
+      "valueProps": ["メディアミックス", "唯一無二の看板"],
+      "mission": "価値を創造し社会に還元",
+      "colors": ["#0052CC", "#36B37E", "#F5A623"]
+    },
+    "source": {"type": "generated", "url": ""},
+    "licenseNote": "Created as bespoke vector artwork for Gaia LLC branding."
+  },
+  {
+    "filename": "images/section-2.svg",
+    "prompt": "Night gradient waves showing signage information flow in blue, green, amber",
+    "alt": "ネオンの波が交差する夜景の導線アート",
+    "usage": "pattern-2 process section",
+    "companyProfile": {
+      "industry": "Signage design",
+      "valueProps": ["動線設計", "保守計画"],
+      "mission": "価値を創造し社会に還元",
+      "colors": ["#0052CC", "#36B37E", "#F5A623"]
+    },
+    "source": {"type": "generated", "url": ""},
+    "licenseNote": "Created as bespoke vector artwork for Gaia LLC branding."
+  },
+  {
+    "filename": "images/hero-3.svg",
+    "prompt": "Bold organic arcs merging pottery warmth and skyline strokes in Gaia palette",
+    "alt": "陶芸の曲線と都市ストロークが交差する大胆なアート",
+    "usage": "pattern-3 hero",
+    "companyProfile": {
+      "industry": "Real estate, design, signage",
+      "valueProps": ["Design × Place", "自由な創造力"],
+      "mission": "価値を創造し社会に還元",
+      "colors": ["#0052CC", "#36B37E", "#F5A623"]
+    },
+    "source": {"type": "generated", "url": ""},
+    "licenseNote": "Created as bespoke vector artwork for Gaia LLC branding."
+  },
+  {
+    "filename": "images/section-3.svg",
+    "prompt": "Warm gradient circles and cool rectangles symbolizing pottery and architecture",
+    "alt": "陶芸の円と建築の矩形を重ねた図形アート",
+    "usage": "pattern-3 philosophy section",
+    "companyProfile": {
+      "industry": "Design consulting",
+      "valueProps": ["クラフト表現", "ブランド体験"],
+      "mission": "価値を創造し社会に還元",
+      "colors": ["#0052CC", "#36B37E", "#F5A623"]
+    },
+    "source": {"type": "generated", "url": ""},
+    "licenseNote": "Created as bespoke vector artwork for Gaia LLC branding."
+  }
+]

--- a/images/hero-1.svg
+++ b/images/hero-1.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Gaia LLCの都市開発とサインデザインを象徴するミニマルアート</title>
+  <desc id="desc">ブランドブルーとグリーンを主体に、建築のレイヤーとサインボックスを組み合わせた抽象構成。中央に昇る光が価値創造を表す。</desc>
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f8fbff" />
+      <stop offset="100%" stop-color="#e9f3ff" />
+    </linearGradient>
+    <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#36b37e" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#0052cc" stop-opacity="0.2" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f5a623" />
+      <stop offset="100%" stop-color="#ffdd9c" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#sky)" />
+  <g opacity="0.45">
+    <rect x="220" y="120" width="180" height="560" fill="#e1ebff" rx="28" />
+    <rect x="430" y="160" width="210" height="520" fill="#d7f3ea" rx="32" />
+    <rect x="660" y="100" width="240" height="580" fill="#dce8ff" rx="32" />
+    <rect x="930" y="220" width="120" height="460" fill="#e9f6ff" rx="24" />
+  </g>
+  <g>
+    <rect x="260" y="260" width="210" height="240" fill="#ffffff" stroke="#0052cc" stroke-width="6" rx="28" />
+    <rect x="520" y="220" width="240" height="280" fill="#ffffff" stroke="#36b37e" stroke-width="6" rx="30" />
+    <rect x="820" y="300" width="160" height="200" fill="#ffffff" stroke="#0052cc" stroke-width="6" rx="26" />
+  </g>
+  <g opacity="0.25">
+    <path d="M140 640 C 260 520, 420 500, 600 620 C 780 740, 960 720, 1140 580" fill="none" stroke="#0052cc" stroke-width="28" stroke-linecap="round" />
+  </g>
+  <g opacity="0.45">
+    <rect x="420" y="80" width="40" height="160" fill="url(#beam)" rx="20" />
+    <rect x="620" y="80" width="40" height="200" fill="url(#beam)" rx="20" />
+    <rect x="820" y="80" width="40" height="180" fill="url(#beam)" rx="20" />
+  </g>
+  <rect x="560" y="440" width="80" height="190" fill="url(#accent)" rx="26" opacity="0.85" />
+  <circle cx="600" cy="360" r="120" fill="none" stroke="#36b37e" stroke-width="14" stroke-dasharray="18 18" opacity="0.65" />
+</svg>

--- a/images/hero-2.svg
+++ b/images/hero-2.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">夜間の街路とデジタルサイネージを抽象化したダークグラデーションアート</title>
+  <desc id="desc">深いネイビーにネオングリーンと琥珀の光を差し込み、看板事業と都市開発の融合を表現。流線形が情報の流れを描く。</desc>
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#36b37e" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#050910" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="band" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f2f6b" />
+      <stop offset="100%" stop-color="#071426" />
+    </linearGradient>
+    <linearGradient id="beam2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#36b37e" />
+      <stop offset="100%" stop-color="#00a887" />
+    </linearGradient>
+    <linearGradient id="amber" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f5a623" />
+      <stop offset="100%" stop-color="#ffcf8b" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="#050910" />
+  <rect x="0" y="0" width="1200" height="800" fill="url(#band)" opacity="0.95" />
+  <circle cx="700" cy="200" r="420" fill="url(#glow)" />
+  <g opacity="0.55">
+    <path d="M-40 520 Q 260 420 520 520 T 1120 520" fill="none" stroke="url(#beam2)" stroke-width="26" stroke-linecap="round" />
+    <path d="M-60 600 Q 260 700 520 640 T 1220 620" fill="none" stroke="url(#amber)" stroke-width="18" stroke-linecap="round" />
+  </g>
+  <g opacity="0.8">
+    <rect x="280" y="180" width="180" height="360" rx="36" fill="rgba(5, 82, 204, 0.6)" />
+    <rect x="520" y="160" width="210" height="420" rx="38" fill="rgba(22, 45, 99, 0.8)" />
+    <rect x="780" y="210" width="160" height="320" rx="32" fill="rgba(15, 62, 125, 0.7)" />
+  </g>
+  <g>
+    <rect x="330" y="260" width="110" height="140" rx="24" fill="#0b1c34" stroke="#36b37e" stroke-width="5" />
+    <rect x="590" y="240" width="140" height="160" rx="28" fill="#071426" stroke="#36b37e" stroke-width="6" />
+    <rect x="830" y="300" width="100" height="130" rx="24" fill="#0b1c34" stroke="#f5a623" stroke-width="5" />
+  </g>
+  <g opacity="0.3">
+    <circle cx="360" cy="140" r="120" fill="#0052cc" />
+    <circle cx="980" cy="100" r="160" fill="#0b1c34" />
+  </g>
+</svg>

--- a/images/hero-3.svg
+++ b/images/hero-3.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">陶芸と都市開発を融合させた大胆なビジュアルアート</title>
+  <desc id="desc">大きなストロークと円弧で土の温かさと都市の構造を共存させ、ブランドカラーで価値創造のダイナミズムを描写。</desc>
+  <defs>
+    <linearGradient id="sunrise" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffe8c7" />
+      <stop offset="100%" stop-color="#fff4e5" />
+    </linearGradient>
+    <linearGradient id="river" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#36b37e" />
+      <stop offset="100%" stop-color="#27c4a6" />
+    </linearGradient>
+    <linearGradient id="skyline" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0052cc" />
+      <stop offset="100%" stop-color="#3b7cff" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#sunrise)" />
+  <path d="M0 520 C 160 360, 320 380, 520 460 S 880 540, 1200 420 L 1200 800 L 0 800 Z" fill="url(#river)" opacity="0.55" />
+  <path d="M0 600 C 140 560, 320 660, 520 620 S 900 560, 1200 640 L 1200 800 L 0 800 Z" fill="#f5a623" opacity="0.35" />
+  <g opacity="0.85">
+    <path d="M200 540 C 220 420, 300 280, 460 260 C 660 240, 760 420, 820 520 C 880 620, 980 660, 1020 720" fill="none" stroke="url(#skyline)" stroke-width="56" stroke-linecap="round" />
+    <circle cx="380" cy="360" r="110" fill="#ffffff" opacity="0.75" />
+    <circle cx="780" cy="340" r="150" fill="#0052cc" opacity="0.18" />
+  </g>
+  <g opacity="0.9">
+    <rect x="240" y="220" width="160" height="200" rx="48" fill="#0052cc" />
+    <rect x="420" y="180" width="200" height="240" rx="60" fill="#36b37e" />
+    <rect x="660" y="220" width="240" height="220" rx="70" fill="#f5a623" />
+  </g>
+  <g opacity="0.5">
+    <path d="M160 720 Q 240 660 320 720 T 480 720 T 640 720 T 800 720 T 960 720 T 1120 720" fill="none" stroke="#0052cc" stroke-width="20" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+</svg>

--- a/images/section-1.svg
+++ b/images/section-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" role="img" aria-labelledby="title desc">
+  <title id="title">都市の区画とサイン計画を表現したラインアート</title>
+  <desc id="desc">直交するグリッドと柔らかな曲線の重なりで不動産開発と看板動線を表す。ブルーとグリーンで信頼と持続性を演出。</desc>
+  <defs>
+    <linearGradient id="lines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0052cc" />
+      <stop offset="100%" stop-color="#36b37e" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="420" rx="32" fill="#f5f7fb" />
+  <g stroke="url(#lines)" stroke-width="6" fill="none">
+    <rect x="80" y="80" width="160" height="260" rx="26" />
+    <rect x="260" y="60" width="150" height="300" rx="32" />
+    <rect x="430" y="110" width="80" height="210" rx="18" />
+  </g>
+  <g stroke="#f5a623" stroke-width="5" fill="none" opacity="0.7">
+    <path d="M60 210 Q 180 120 300 180 T 540 160" />
+    <path d="M60 280 Q 160 360 280 310 T 540 340" />
+  </g>
+  <circle cx="180" cy="140" r="32" fill="#36b37e" opacity="0.35" />
+  <circle cx="330" cy="240" r="28" fill="#0052cc" opacity="0.25" />
+</svg>

--- a/images/section-2.svg
+++ b/images/section-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" role="img" aria-labelledby="title desc">
+  <title id="title">夜景の導線と情報の流れを示すグラデーションウェーブ</title>
+  <desc id="desc">深い紺の背景にサインの光跡をイメージした波型が交差し、広告と不動産の連携を可視化。</desc>
+  <defs>
+    <linearGradient id="wave1" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0052cc" />
+      <stop offset="100%" stop-color="#36b37e" />
+    </linearGradient>
+    <linearGradient id="wave2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f5a623" />
+      <stop offset="100%" stop-color="#ffcf8b" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="420" rx="30" fill="#050910" />
+  <path d="M0 260 C 120 210, 220 320, 320 280 S 520 220, 600 260 L 600 420 L 0 420 Z" fill="url(#wave1)" opacity="0.55" />
+  <path d="M0 220 C 140 140, 240 220, 340 200 S 520 160, 600 200 L 600 420 L 0 420 Z" fill="url(#wave2)" opacity="0.45" />
+  <g opacity="0.3">
+    <circle cx="140" cy="120" r="40" fill="#36b37e" />
+    <circle cx="460" cy="90" r="62" fill="#0052cc" />
+    <circle cx="360" cy="140" r="28" fill="#f5a623" />
+  </g>
+</svg>

--- a/images/section-3.svg
+++ b/images/section-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 420" role="img" aria-labelledby="title desc">
+  <title id="title">陶芸の曲線と都市区画を組み合わせた図形アート</title>
+  <desc id="desc">柔らかな円と直線が交差し、ガイアの創造性と不動産知見の両立を表現。温かなグラデーションで感性を強調。</desc>
+  <defs>
+    <linearGradient id="warm" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f5a623" />
+      <stop offset="100%" stop-color="#ffd39a" />
+    </linearGradient>
+    <linearGradient id="cool" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0052cc" />
+      <stop offset="100%" stop-color="#36b37e" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="420" rx="36" fill="#ffffff" />
+  <circle cx="180" cy="180" r="120" fill="url(#warm)" opacity="0.8" />
+  <rect x="260" y="100" width="200" height="220" rx="50" fill="url(#cool)" opacity="0.75" />
+  <path d="M60 320 C 180 260, 300 360, 420 320 S 580 300, 600 360" fill="none" stroke="#0052cc" stroke-width="14" stroke-linecap="round" stroke-dasharray="20 20" opacity="0.7" />
+  <circle cx="420" cy="260" r="48" fill="#ffffff" opacity="0.6" />
+  <circle cx="120" cy="320" r="42" fill="#36b37e" opacity="0.45" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gaia LLC Design Explorations</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body class="index">
+  <header class="site-header" role="banner">
+    <nav aria-label="Primary">
+      <a class="brand" href="index.html" aria-label="Gaia LLC top">Gaia LLC</a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">メニュー</button>
+      <ul id="primary-nav" class="nav">
+        <li><a href="pattern-1.html">Pattern 1</a></li>
+        <li><a href="pattern-2.html">Pattern 2</a></li>
+        <li><a href="pattern-3.html">Pattern 3</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h1>Gaia LLC Brand UI Concepts</h1>
+      <p>3つのビジュアルテーマで会社概要と価値創造メッセージを表現したデザイン案をお選びいただけます。</p>
+    </section>
+  </main>
+  <script src="assets/script.js"></script>
+</body>
+</html>

--- a/pattern-1.html
+++ b/pattern-1.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gaia LLC | Pattern 1 - Modern Minimal</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body class="pattern-1">
+  <!-- companyProfile: {industry:"Real estate development & signage design", valueProps:["価値創造","Design × Place","独自看板最適化","不動産ネットワーク"], audience:["不動産オーナー","投資家","店舗オーナー"], mission:"価値を創造し社会に還元", colors:["#0052CC","#36B37E","#F5A623"], motifs:["architectural grid","sign frames","value beam"]} -->
+  <!-- visualMapping: industry -> 建築レイヤーとサインボックス, colors -> 線とアクセントにブランドカラー, mission -> 光のリングと上昇ラインで価値創造の流れを示唆 -->
+  <header class="site-header" role="banner">
+    <nav aria-label="Primary">
+      <a class="brand" href="index.html" aria-label="Gaia LLC top">Gaia LLC</a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">メニュー</button>
+      <ul id="primary-nav" class="nav">
+        <li><a href="pattern-1.html" aria-current="page">Pattern 1</a></li>
+        <li><a href="pattern-2.html">Pattern 2</a></li>
+        <li><a href="pattern-3.html">Pattern 3</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section class="hero" aria-labelledby="hero-heading">
+      <div>
+        <svg class="hero-art" viewBox="0 0 1200 800" role="img" aria-labelledby="hero1-title hero1-desc">
+          <title id="hero1-title">Gaia LLCの都市開発とサインデザインを象徴するミニマルアート</title>
+          <desc id="hero1-desc">ブランドブルーとグリーンを主体に、建築のレイヤーとサインボックスを組み合わせた抽象構成。中央に昇る光が価値創造を表す。</desc>
+          <defs>
+            <linearGradient id="hero1-sky" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#f8fbff" />
+              <stop offset="100%" stop-color="#e9f3ff" />
+            </linearGradient>
+            <linearGradient id="hero1-beam" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#36b37e" stop-opacity="0.9" />
+              <stop offset="100%" stop-color="#0052cc" stop-opacity="0.2" />
+            </linearGradient>
+            <linearGradient id="hero1-accent" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#f5a623" />
+              <stop offset="100%" stop-color="#ffdd9c" />
+            </linearGradient>
+          </defs>
+          <rect width="1200" height="800" fill="url(#hero1-sky)" />
+          <g opacity="0.45">
+            <rect x="220" y="120" width="180" height="560" fill="#e1ebff" rx="28" />
+            <rect x="430" y="160" width="210" height="520" fill="#d7f3ea" rx="32" />
+            <rect x="660" y="100" width="240" height="580" fill="#dce8ff" rx="32" />
+            <rect x="930" y="220" width="120" height="460" fill="#e9f6ff" rx="24" />
+          </g>
+          <g>
+            <rect x="260" y="260" width="210" height="240" fill="#ffffff" stroke="#0052cc" stroke-width="6" rx="28" />
+            <rect x="520" y="220" width="240" height="280" fill="#ffffff" stroke="#36b37e" stroke-width="6" rx="30" />
+            <rect x="820" y="300" width="160" height="200" fill="#ffffff" stroke="#0052cc" stroke-width="6" rx="26" />
+          </g>
+          <g opacity="0.25">
+            <path d="M140 640 C 260 520, 420 500, 600 620 C 780 740, 960 720, 1140 580" fill="none" stroke="#0052cc" stroke-width="28" stroke-linecap="round" />
+          </g>
+          <g opacity="0.45">
+            <rect x="420" y="80" width="40" height="160" fill="url(#hero1-beam)" rx="20" />
+            <rect x="620" y="80" width="40" height="200" fill="url(#hero1-beam)" rx="20" />
+            <rect x="820" y="80" width="40" height="180" fill="url(#hero1-beam)" rx="20" />
+          </g>
+          <rect x="560" y="440" width="80" height="190" fill="url(#hero1-accent)" rx="26" opacity="0.85" />
+          <circle cx="600" cy="360" r="120" fill="none" stroke="#36b37e" stroke-width="14" stroke-dasharray="18 18" opacity="0.65" />
+        </svg>
+      </div>
+      <div class="hero-content">
+        <h1 id="hero-heading">価値創造で街と人をつなぐモダンソリューション</h1>
+        <p class="lead">不動産開発から看板設計、保険までを横断するGaia LLCの強みを、都市のレイヤーとサインのフレームで表現しました。</p>
+        <a class="cta" href="#services">サービスを見る</a>
+      </div>
+    </section>
+
+    <section id="services" class="section" aria-labelledby="services-heading">
+      <div>
+        <h2 id="services-heading">統合型サービスライン</h2>
+        <p>地域の価値を磨き上げるために、不動産・建築・広告・保険をワンストップで提供。ユーザー視点で最適な組み合わせを提案します。</p>
+        <ul class="section-list">
+          <li>不動産事業とコンサルティングで街区のポテンシャルを最大化</li>
+          <li>建築設計と住宅・別荘地開発で唯一無二の空間を創出</li>
+          <li>看板・ストリート広告と保険サービスで持続的な運用を支援</li>
+        </ul>
+      </div>
+      <div class="section-media">
+        <svg viewBox="0 0 600 420" role="img" aria-labelledby="sec1-title sec1-desc">
+          <title id="sec1-title">都市の区画とサイン計画を表現したラインアート</title>
+          <desc id="sec1-desc">直交するグリッドと柔らかな曲線の重なりで不動産開発と看板動線を表す。ブルーとグリーンで信頼と持続性を演出。</desc>
+          <defs>
+            <linearGradient id="sec1-lines" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#0052cc" />
+              <stop offset="100%" stop-color="#36b37e" />
+            </linearGradient>
+          </defs>
+          <rect width="600" height="420" rx="32" fill="#f5f7fb" />
+          <g stroke="url(#sec1-lines)" stroke-width="6" fill="none">
+            <rect x="80" y="80" width="160" height="260" rx="26" />
+            <rect x="260" y="60" width="150" height="300" rx="32" />
+            <rect x="430" y="110" width="80" height="210" rx="18" />
+          </g>
+          <g stroke="#f5a623" stroke-width="5" fill="none" opacity="0.7">
+            <path d="M60 210 Q 180 120 300 180 T 540 160" />
+            <path d="M60 280 Q 160 360 280 310 T 540 340" />
+          </g>
+          <circle cx="180" cy="140" r="32" fill="#36b37e" opacity="0.35" />
+          <circle cx="330" cy="240" r="28" fill="#0052cc" opacity="0.25" />
+        </svg>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="approach-heading">
+      <div>
+        <h2 id="approach-heading">価値創造のアプローチ</h2>
+        <p>「本質は何か」「誰のためか」を問い続け、プロジェクトごとに地域との共創とデータ分析を行い価値を可視化。社会への還元を軸に設計します。</p>
+        <ul class="section-list">
+          <li>地域社会とのリレーションを活かしたコンセプト開発</li>
+          <li>用途に応じたモジュール設計で迅速なプロトタイピング</li>
+          <li>保険と資産戦略を含めた長期的な運用デザイン</li>
+        </ul>
+      </div>
+      <div class="section-media" aria-hidden="true">
+        <svg viewBox="0 0 600 420" class="decor" role="presentation">
+          <defs>
+            <linearGradient id="sec1-decor" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="rgba(0,82,204,0.18)" />
+              <stop offset="100%" stop-color="rgba(54,179,126,0.1)" />
+            </linearGradient>
+          </defs>
+          <rect width="600" height="420" rx="32" fill="url(#sec1-decor)" />
+          <rect x="80" y="100" width="440" height="220" rx="28" fill="rgba(255,255,255,0.6)" />
+        </svg>
+      </div>
+    </section>
+
+    <footer>
+      <p>© Gaia LLC — 熊本を拠点に価値創造を実装するパートナー。</p>
+    </footer>
+  </main>
+  <script src="assets/script.js"></script>
+</body>
+</html>

--- a/pattern-2.html
+++ b/pattern-2.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gaia LLC | Pattern 2 - Dark Gradient</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body class="pattern-2">
+  <!-- companyProfile: {industry:"Real estate, construction design, signage, insurance", valueProps:["価値創造","唯一無二の看板","メディアミックス","不動産投資サポート"], audience:["路面店舗","デベロッパー","投資家"], mission:"価値を創造し社会に還元", colors:["#0052CC","#36B37E","#F5A623"], motifs:["night skyline","light trails","route wave"]} -->
+  <!-- visualMapping: industry -> 夜間の街路とサイネージの光, colors -> ネオンのグリーンと琥珀でブランド配色, mission -> 流線形の光跡で価値が広がるイメージ -->
+  <header class="site-header" role="banner">
+    <nav aria-label="Primary">
+      <a class="brand" href="index.html" aria-label="Gaia LLC top">Gaia LLC</a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">メニュー</button>
+      <ul id="primary-nav" class="nav">
+        <li><a href="pattern-1.html">Pattern 1</a></li>
+        <li><a href="pattern-2.html" aria-current="page">Pattern 2</a></li>
+        <li><a href="pattern-3.html">Pattern 3</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section class="hero" aria-labelledby="hero2-heading">
+      <div>
+        <svg class="hero-art" viewBox="0 0 1200 800" role="img" aria-labelledby="hero2-title hero2-desc">
+          <title id="hero2-title">夜間の街路とデジタルサイネージを抽象化したダークグラデーションアート</title>
+          <desc id="hero2-desc">深いネイビーにネオングリーンと琥珀の光を差し込み、看板事業と都市開発の融合を表現。流線形が情報の流れを描く。</desc>
+          <defs>
+            <radialGradient id="hero2-glow" cx="50%" cy="20%" r="70%">
+              <stop offset="0%" stop-color="#36b37e" stop-opacity="0.8" />
+              <stop offset="100%" stop-color="#050910" stop-opacity="0" />
+            </radialGradient>
+            <linearGradient id="hero2-band" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#0f2f6b" />
+              <stop offset="100%" stop-color="#071426" />
+            </linearGradient>
+            <linearGradient id="hero2-beam" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#36b37e" />
+              <stop offset="100%" stop-color="#00a887" />
+            </linearGradient>
+            <linearGradient id="hero2-amber" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#f5a623" />
+              <stop offset="100%" stop-color="#ffcf8b" />
+            </linearGradient>
+          </defs>
+          <rect width="1200" height="800" fill="#050910" />
+          <rect x="0" y="0" width="1200" height="800" fill="url(#hero2-band)" opacity="0.95" />
+          <circle cx="700" cy="200" r="420" fill="url(#hero2-glow)" />
+          <g opacity="0.55">
+            <path d="M-40 520 Q 260 420 520 520 T 1120 520" fill="none" stroke="url(#hero2-beam)" stroke-width="26" stroke-linecap="round" />
+            <path d="M-60 600 Q 260 700 520 640 T 1220 620" fill="none" stroke="url(#hero2-amber)" stroke-width="18" stroke-linecap="round" />
+          </g>
+          <g opacity="0.8">
+            <rect x="280" y="180" width="180" height="360" rx="36" fill="rgba(5, 82, 204, 0.6)" />
+            <rect x="520" y="160" width="210" height="420" rx="38" fill="rgba(22, 45, 99, 0.8)" />
+            <rect x="780" y="210" width="160" height="320" rx="32" fill="rgba(15, 62, 125, 0.7)" />
+          </g>
+          <g>
+            <rect x="330" y="260" width="110" height="140" rx="24" fill="#0b1c34" stroke="#36b37e" stroke-width="5" />
+            <rect x="590" y="240" width="140" height="160" rx="28" fill="#071426" stroke="#36b37e" stroke-width="6" />
+            <rect x="830" y="300" width="100" height="130" rx="24" fill="#0b1c34" stroke="#f5a623" stroke-width="5" />
+          </g>
+          <g opacity="0.3">
+            <circle cx="360" cy="140" r="120" fill="#0052cc" />
+            <circle cx="980" cy="100" r="160" fill="#0b1c34" />
+          </g>
+        </svg>
+      </div>
+      <div class="hero-content">
+        <h1 id="hero2-heading">夜の街を彩る価値創造ネットワーク</h1>
+        <p class="lead">夜間でも視認性を高める看板や外装を、土地情報と保険戦略まで組み合わせてプランニング。メディアミックスで唯一無二の存在感を生み出します。</p>
+        <a class="cta" href="#experience">プロセスを見る</a>
+      </div>
+    </section>
+
+    <section id="experience" class="section" aria-labelledby="experience-heading">
+      <div>
+        <h2 id="experience-heading">光と空間の設計プロセス</h2>
+        <p>デザインと不動産条件を同時に検証し、投資効果と地域調和を両立。夜間の動線を可視化し、効果的なサイン配置を実現します。</p>
+        <ul class="section-list">
+          <li>ゾーニング・景観条例に沿ったサインシミュレーション</li>
+          <li>電力・保守を含めたライフサイクル設計</li>
+          <li>保険商品との連動でリスク最適化</li>
+        </ul>
+      </div>
+      <div class="section-media">
+        <svg viewBox="0 0 600 420" role="img" aria-labelledby="sec2-title sec2-desc">
+          <title id="sec2-title">夜景の導線と情報の流れを示すグラデーションウェーブ</title>
+          <desc id="sec2-desc">深い紺の背景にサインの光跡をイメージした波型が交差し、広告と不動産の連携を可視化。</desc>
+          <defs>
+            <linearGradient id="sec2-wave1" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#0052cc" />
+              <stop offset="100%" stop-color="#36b37e" />
+            </linearGradient>
+            <linearGradient id="sec2-wave2" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#f5a623" />
+              <stop offset="100%" stop-color="#ffcf8b" />
+            </linearGradient>
+          </defs>
+          <rect width="600" height="420" rx="30" fill="#050910" />
+          <path d="M0 260 C 120 210, 220 320, 320 280 S 520 220, 600 260 L 600 420 L 0 420 Z" fill="url(#sec2-wave1)" opacity="0.55" />
+          <path d="M0 220 C 140 140, 240 220, 340 200 S 520 160, 600 200 L 600 420 L 0 420 Z" fill="url(#sec2-wave2)" opacity="0.45" />
+          <g opacity="0.3">
+            <circle cx="140" cy="120" r="40" fill="#36b37e" />
+            <circle cx="460" cy="90" r="62" fill="#0052cc" />
+            <circle cx="360" cy="140" r="28" fill="#f5a623" />
+          </g>
+        </svg>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="message-heading">
+      <div>
+        <h2 id="message-heading">社会への還元を見据えた投資視点</h2>
+        <p>Gaia LLCは熊本から全国へ、地域資産の再価値化を推進。投資効果と地域の暮らしに寄り添う視点で、持続可能な都市景観を支えます。</p>
+        <ul class="section-list">
+          <li>地域コミュニティと協働する長期運営</li>
+          <li>データ分析によるパフォーマンス評価</li>
+          <li>リスクマネジメントとサポート体制の構築</li>
+        </ul>
+      </div>
+      <div class="section-media" aria-hidden="true">
+        <svg viewBox="0 0 600 420" role="presentation" class="decor">
+          <defs>
+            <radialGradient id="sec2-glow" cx="50%" cy="50%" r="70%">
+              <stop offset="0%" stop-color="rgba(54,179,126,0.6)" />
+              <stop offset="100%" stop-color="rgba(5,9,16,0)" />
+            </radialGradient>
+          </defs>
+          <rect width="600" height="420" rx="36" fill="#071426" />
+          <circle cx="300" cy="210" r="180" fill="url(#sec2-glow)" />
+        </svg>
+      </div>
+    </section>
+
+    <footer>
+      <p>© Gaia LLC — 価値創造で夜の都市景観をアップデート。</p>
+    </footer>
+  </main>
+  <script src="assets/script.js"></script>
+</body>
+</html>

--- a/pattern-3.html
+++ b/pattern-3.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gaia LLC | Pattern 3 - Bold &amp; Visual Rich</title>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body class="pattern-3">
+  <!-- companyProfile: {industry:"Real estate・建築設計・看板・保険", valueProps:["Design × Place","自由な創造力","唯一無二の広告","価値創造"], audience:["感性を重視するオーナー","ライフスタイル提案が必要な顧客"], mission:"価値を創造し社会に還元", colors:["#0052CC","#36B37E","#F5A623"], motifs:["organic arcs","architectural strokes","earthen warmth"]} -->
+  <!-- visualMapping: industry -> 建築ストロークと陶芸の曲線を融合, colors -> ブランドカラーを大胆なブロック配分に使用, mission -> 重層的な波とサークルで価値創造のうねりを演出 -->
+  <header class="site-header" role="banner">
+    <nav aria-label="Primary">
+      <a class="brand" href="index.html" aria-label="Gaia LLC top">Gaia LLC</a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">メニュー</button>
+      <ul id="primary-nav" class="nav">
+        <li><a href="pattern-1.html">Pattern 1</a></li>
+        <li><a href="pattern-2.html">Pattern 2</a></li>
+        <li><a href="pattern-3.html" aria-current="page">Pattern 3</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section class="hero" aria-labelledby="hero3-heading">
+      <div>
+        <svg class="hero-art" viewBox="0 0 1200 800" role="img" aria-labelledby="hero3-title hero3-desc">
+          <title id="hero3-title">陶芸と都市開発を融合させた大胆なビジュアルアート</title>
+          <desc id="hero3-desc">大きなストロークと円弧で土の温かさと都市の構造を共存させ、ブランドカラーで価値創造のダイナミズムを描写。</desc>
+          <defs>
+            <linearGradient id="hero3-sunrise" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#ffe8c7" />
+              <stop offset="100%" stop-color="#fff4e5" />
+            </linearGradient>
+            <linearGradient id="hero3-river" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#36b37e" />
+              <stop offset="100%" stop-color="#27c4a6" />
+            </linearGradient>
+            <linearGradient id="hero3-skyline" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#0052cc" />
+              <stop offset="100%" stop-color="#3b7cff" />
+            </linearGradient>
+          </defs>
+          <rect width="1200" height="800" fill="url(#hero3-sunrise)" />
+          <path d="M0 520 C 160 360, 320 380, 520 460 S 880 540, 1200 420 L 1200 800 L 0 800 Z" fill="url(#hero3-river)" opacity="0.55" />
+          <path d="M0 600 C 140 560, 320 660, 520 620 S 900 560, 1200 640 L 1200 800 L 0 800 Z" fill="#f5a623" opacity="0.35" />
+          <g opacity="0.85">
+            <path d="M200 540 C 220 420, 300 280, 460 260 C 660 240, 760 420, 820 520 C 880 620, 980 660, 1020 720" fill="none" stroke="url(#hero3-skyline)" stroke-width="56" stroke-linecap="round" />
+            <circle cx="380" cy="360" r="110" fill="#ffffff" opacity="0.75" />
+            <circle cx="780" cy="340" r="150" fill="#0052cc" opacity="0.18" />
+          </g>
+          <g opacity="0.9">
+            <rect x="240" y="220" width="160" height="200" rx="48" fill="#0052cc" />
+            <rect x="420" y="180" width="200" height="240" rx="60" fill="#36b37e" />
+            <rect x="660" y="220" width="240" height="220" rx="70" fill="#f5a623" />
+          </g>
+          <g opacity="0.5">
+            <path d="M160 720 Q 240 660 320 720 T 480 720 T 640 720 T 800 720 T 960 720 T 1120 720" fill="none" stroke="#0052cc" stroke-width="20" stroke-linecap="round" stroke-linejoin="round" />
+          </g>
+        </svg>
+      </div>
+      <div class="hero-content">
+        <h1 id="hero3-heading">感性を形にするGaiaのクリエイティブエンジン</h1>
+        <p class="lead">陶芸の温もりと都市設計の精度を重ね合わせ、ブランドや街区にフィットする唯一無二の価値を共創します。</p>
+        <a class="cta" href="#story">ストーリーを読む</a>
+      </div>
+    </section>
+
+    <section id="story" class="section" aria-labelledby="story-heading">
+      <div>
+        <h2 id="story-heading">Design × Place の哲学</h2>
+        <p>土地の文脈を読み解き、素材感や光を織り交ぜたデザインで人の感性に響く空間を提案。住宅・別荘地から商業施設まで、体験価値を軸に仕立てます。</p>
+        <ul class="section-list">
+          <li>地域文化を活かすマテリアルとクラフトの選定</li>
+          <li>用途別にシナリオを描くストーリーテリング設計</li>
+          <li>施工から広告表現まで一貫したブランド体験</li>
+        </ul>
+      </div>
+      <div class="section-media">
+        <svg viewBox="0 0 600 420" role="img" aria-labelledby="sec3-title sec3-desc">
+          <title id="sec3-title">陶芸の曲線と都市区画を組み合わせた図形アート</title>
+          <desc id="sec3-desc">柔らかな円と直線が交差し、ガイアの創造性と不動産知見の両立を表現。温かなグラデーションで感性を強調。</desc>
+          <defs>
+            <linearGradient id="sec3-warm" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#f5a623" />
+              <stop offset="100%" stop-color="#ffd39a" />
+            </linearGradient>
+            <linearGradient id="sec3-cool" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#0052cc" />
+              <stop offset="100%" stop-color="#36b37e" />
+            </linearGradient>
+          </defs>
+          <rect width="600" height="420" rx="36" fill="#ffffff" />
+          <circle cx="180" cy="180" r="120" fill="url(#sec3-warm)" opacity="0.8" />
+          <rect x="260" y="100" width="200" height="220" rx="50" fill="url(#sec3-cool)" opacity="0.75" />
+          <path d="M60 320 C 180 260, 300 360, 420 320 S 580 300, 600 360" fill="none" stroke="#0052cc" stroke-width="14" stroke-linecap="round" stroke-dasharray="20 20" opacity="0.7" />
+          <circle cx="420" cy="260" r="48" fill="#ffffff" opacity="0.6" />
+          <circle cx="120" cy="320" r="42" fill="#36b37e" opacity="0.45" />
+        </svg>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="creation-heading">
+      <div>
+        <h2 id="creation-heading">自由な創造力を支える仕組み</h2>
+        <p>Gaia LLCは不動産ネットワークと保険知識を組み合わせ、クリエイティブの裏付けとなるデータと運用体制を提供します。</p>
+        <ul class="section-list">
+          <li>ビジョン策定からプロトタイプ制作までのアジャイル体制</li>
+          <li>土地活用と広告収益を両立させるファイナンス支援</li>
+          <li>保守・保証まで見据えた長期パートナーシップ</li>
+        </ul>
+      </div>
+      <div class="section-media" aria-hidden="true">
+        <svg viewBox="0 0 600 420" role="presentation" class="decor">
+          <defs>
+            <linearGradient id="sec3-decor" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="rgba(245,166,35,0.35)" />
+              <stop offset="100%" stop-color="rgba(0,82,204,0.18)" />
+            </linearGradient>
+          </defs>
+          <rect width="600" height="420" rx="36" fill="url(#sec3-decor)" />
+          <circle cx="180" cy="180" r="140" fill="rgba(255,255,255,0.55)" />
+        </svg>
+      </div>
+    </section>
+
+    <footer>
+      <p>© Gaia LLC — 感性と価値の裏付けで未来をデザイン。</p>
+    </footer>
+  </main>
+  <script src="assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a shared navigation index that links to three Gaia LLC design explorations rooted in the provided company profile
- implement modern minimal, dark gradient, and bold visual pattern pages with inline SVG hero art and supporting sections mapped to Gaia LLC motifs
- add responsive global styles, accessible navigation behavior, and an image manifest documenting bespoke generative artwork

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68ccebf44f308331a6b7ea1607181804